### PR TITLE
fix environment separation in antq example

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,6 +304,7 @@ $ clojure -M:prn --foo=1
 ``` clojure
 :antq {:deps {org.babashka/cli {:mvn/version "0.2.17"}
               com.github.liquidz/antq {:mvn/version "1.7.798"}}
+       :paths []
        :main-opts ["-m" "babashka.cli.exec" "antq.tool" "outdated"]
        :org.babashka/cli {:coerce {:skip []}}}
 ```


### PR DESCRIPTION
`-T` achieves deps&path environment separation by itself. `-M` needs to be told explicitly.

Say, there's a project with a broken user.clj:

```sh
cat <<EOF > deps.edn
{:paths ["src"]
 :aliases
 {:antq {:deps {org.babashka/cli {:mvn/version "0.2.17"}
                com.github.liquidz/antq {:mvn/version "1.7.798"}}
         :main-opts ["-m" "babashka.cli.exec" "antq.tool" "outdated"]
         :org.babashka/cli {:coerce {:skip []}}}}}
EOF

mkdir src
echo '(ns user' > src/user.clj

clj -M:antq --upgrade --skip github-action
```

fails with

```
Exception in thread "main" Syntax error reading source at (user.clj:2:1).
	at clojure.lang.Compiler.load(Compiler.java:7660)
	at clojure.lang.RT.loadResourceScript(RT.java:381)
	at clojure.lang.RT.loadResourceScript(RT.java:368)
	at clojure.lang.RT.maybeLoadResourceScript(RT.java:364)
	at clojure.lang.RT.doInit(RT.java:486)
	at clojure.lang.RT.init(RT.java:467)
	at clojure.main.main(main.java:38)
Caused by: java.lang.RuntimeException: EOF while reading, starting at line 1
	at clojure.lang.Util.runtimeException(Util.java:221)
	at clojure.lang.LispReader.readDelimitedList(LispReader.java:1405)
	at clojure.lang.LispReader$ListReader.invoke(LispReader.java:1243)
	at clojure.lang.LispReader.read(LispReader.java:285)
	at clojure.lang.LispReader.read(LispReader.java:216)
	at clojure.lang.Compiler.load(Compiler.java:7647)
```

Adding `:paths []` to the `:antq` alias fixes this.