### PR TITLE
Fix README.md sample code indentation level

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ writing extra boilerplate.
 In your `deps.edn` `:aliases` entry, add:
 
 ``` clojure
-:exec {:deps {org.babashka/cli {:mvn/version "0.2.19"}
+:exec {:deps {org.babashka/cli {:mvn/version "0.2.19"}}
        :main-opts ["-m" "babashka.cli.exec"]}
 ```
 


### PR DESCRIPTION
`:main-opts` key should live on the same level as `:deps`