### PR TITLE
Fix default-width calculation in format-opts

### DIFF
--- a/src/babashka/cli.cljc
+++ b/src/babashka/cli.cljc
@@ -334,7 +334,7 @@
                   (let [alias-width (max alias-width (if alias (count (kw->str alias)) 0))
                         long-opt-width (max long-opt-width (count (kw->str option)))
                         ref-width (max ref-width (if ref (count (str ref)) 0))
-                        default-width (max default-width (if default (count (or (str default-desc)
+                        default-width (max default-width (if default (count (or default-desc
                                                                                 (str default))) 0))
                         description-width (max description-width (if desc (count (str desc)) 0))]
                     {:alias-width alias-width

--- a/src/babashka/cli.cljc
+++ b/src/babashka/cli.cljc
@@ -334,8 +334,9 @@
                   (let [alias-width (max alias-width (if alias (count (kw->str alias)) 0))
                         long-opt-width (max long-opt-width (count (kw->str option)))
                         ref-width (max ref-width (if ref (count (str ref)) 0))
-                        default-width (max default-width (if default (count (or default-desc
-                                                                                (str default))) 0))
+                        default? (or default-desc default)
+                        default-width (max default-width (if default? (count (or default-desc
+                                                                                 default)) 0))
                         description-width (max description-width (if desc (count (str desc)) 0))]
                     {:alias-width alias-width
                      :long-opt-width long-opt-width

--- a/src/babashka/cli.cljc
+++ b/src/babashka/cli.cljc
@@ -336,7 +336,7 @@
                         ref-width (max ref-width (if ref (count (str ref)) 0))
                         default? (or default-desc default)
                         default-width (max default-width (if default? (count (or default-desc
-                                                                                 default)) 0))
+                                                                                 (-> default str not-empty))) 0))
                         description-width (max description-width (if desc (count (str desc)) 0))]
                     {:alias-width alias-width
                      :long-opt-width long-opt-width

--- a/test/babashka/cli_test.cljc
+++ b/test/babashka/cli_test.cljc
@@ -104,7 +104,7 @@
       --paths           src test Paths of files to transform.
   -p, --pretty                   Pretty-print output.")
            (str/trim (cli/format-opts {:spec spec
-                                      :order [:from :to :paths :pretty]}))))
+                                       :order [:from :to :paths :pretty]}))))
     (is (= {:coerce {:from :keyword,
                      :to :keyword, :paths []},
             :aliases {:i :from, :o :to, :p :pretty},
@@ -120,13 +120,13 @@
                                       :coerce []
                                       :default ["src" "test"]
                                       :default-desc "src test"}]]}))))
-    (is (= {:opts {:from :edn, :to :json, :paths ["src" "test"]}}
-           (cli/parse-args [] {:spec spec})))
-    (is (= "  --deps/root The root"
-           (cli/format-opts {:spec [[:deps/root {:desc "The root"}]]})))
-    (is (= #:deps{:root "the-root"}
-           (cli/parse-opts ["--deps/root" "the-root"]
-                           {:spec [[:deps/root {:desc "The root"}]]})))))
+   (is (= {:opts {:from :edn, :to :json, :paths ["src" "test"]}}
+          (cli/parse-args [] {:spec spec})))
+   (is (= "  --deps/root The root"
+          (cli/format-opts {:spec [[:deps/root {:desc "The root"}]]})))
+   (is (= #:deps{:root "the-root"}
+          (cli/parse-opts ["--deps/root" "the-root"]
+                          {:spec [[:deps/root {:desc "The root"}]]})))))
 
 (deftest args-test
   (is (submap? {:foo true} (cli/parse-opts ["--foo" "--"])))
@@ -134,8 +134,8 @@
     (is (submap? {:foo true} res))
     (is (submap? {:org.babashka/cli {:args ["a"]}} (meta res))))
   (is (= {:args ["do" "something" "--now"], :opts {:classpath "src"}}
-         (cli/parse-args ["--classpath" "src" "do" "something" "--now"]
-                         )))
+         (cli/parse-args ["--classpath" "src" "do" "something" "--now"])))
+
   (is (= {:cmds ["do" "something"], :opts {:now true}}
          (cli/parse-args ["do" "something" "--now"])))
   (is (= {:args ["ssh://foo"], :cmds ["git" "push"], :opts {:force true}}
@@ -178,5 +178,13 @@
     (is (submap? {:foo [:bar :baz]} (cli/parse-opts [":foo" ":bar" ":foo" ":baz"] {:coerce {:foo []}}))))
   (is (= 1 (cli/auto-coerce 1)))
   (is (= "1. This is a title." (cli/auto-coerce "1. This is a title.")))
-  (is (= ":1. This is a title." (cli/auto-coerce ":1. This is a title.")))
-)
+  (is (= ":1. This is a title." (cli/auto-coerce ":1. This is a title."))))
+
+(deftest format-opts-test
+  (testing "default width with default and default-desc"
+    (is (= "  -f, --foo <foo> yupyupyupyup Thingy\n  -b, --bar <bar> Mos def      Barbarbar"
+           (cli/format-opts
+             {:spec {:foo {:alias :f, :default "yupyupyupyup", :ref "<foo>"
+                           :desc "Thingy"}
+                     :bar {:alias :b, :default "sure", :ref "<bar>"
+                           :desc "Barbarbar" :default-desc "Mos def"}}})))))


### PR DESCRIPTION
`(str nil)` returns `""`, but this will always be a string I think.

This fixes the width for the `:default` and `:default-desc` fields. Prior to this change `default-width` would be 0 when there was no `default-desc` because `(str nil)` returns `""`. And the width calculation would be off when there was only a `:default-desc` because the if conditional was only looking for `default`.

If my assumption that `default-desc` doesn't need coercion to string is incorrect, I can do this instead:
`(-> default-desc str not-empty)`