### PR TITLE
Add :closed opt to parse-opts

### DIFF
--- a/src/babashka/cli.cljc
+++ b/src/babashka/cli.cljc
@@ -202,7 +202,7 @@
   - `:coerce`: a map of option (keyword) names to type keywords (optionally wrapped in a collection.)
   - `:aliases`: a map of short names to long names.
   - `:spec`: a spec of options. See [spec]().
-  - `:closed`: (bool or set of keys) throw an exception if there are options not defined in the spec (if true) or the set of keys.
+  - `:closed`: (bool or set of keys) throw an exception if there are options not defined in :spec, :aliases, and/or :coerce (if true) or the set of keys.
 
   Examples:
 
@@ -228,7 +228,7 @@
          exec-args (:exec-args opts)
          no-keyword-opts (:no-keyword-opts opts)
          closed (if (= true (:closed opts))
-                  (some-> spec keys (concat (keys aliases)) set)
+                  (some-> spec keys (concat (keys aliases)) (concat (keys coerce-opts)) set)
                   (:closed opts))
          [cmds opts] (split-with #(not (or (when-not no-keyword-opts (str/starts-with? % ":"))
                                            (str/starts-with? % "-"))) args)

--- a/test/babashka/cli_test.cljc
+++ b/test/babashka/cli_test.cljc
@@ -65,7 +65,29 @@
     (is (submap? '{:foo [a b]
                    :skip true}
                  (cli/parse-opts ["--skip" "--foo=a" "--foo=b"]
-                                 {:coerce {:foo [:symbol]}})))))
+                                 {:coerce {:foo [:symbol]}}))))
+  (testing ":closed true w/o spec behaves like not closed"
+    (is (= {:foo "bar" :baz "qux"} (cli/parse-opts ["--foo=bar" "--baz" "qux"]))))
+  (testing ":closed true w/ spec allows opts & aliases in spec"
+    (is (= {:foo "bar" :baz true}
+           (cli/parse-opts ["--foo=bar" "-b"]
+                           {:spec {:foo {} :baz {:alias :b}}
+                            :closed true}))))
+  (testing ":closed true w/ spec throws w/ opt that is not a key nor alias in spec"
+    (is (thrown-with-msg? #?(:clj Exception :cljs :default) #"Unknown option -b"
+                          (cli/parse-opts ["--foo=bar" "-b"]
+                                          {:spec {:foo {}}
+                                           :closed true}))))
+  (testing ":closed #{:foo} w/ only :foo in opts is allowed"
+    (is (= {:foo "bar"} (cli/parse-opts ["--foo=bar"]
+                                        {:closed #{:foo}}))))
+  (testing ":closed #{:foo :bar} w/ only :bar in opts is allowed"
+    (is (= {:bar true} (cli/parse-opts ["--bar"]
+                                       {:closed #{:foo :bar}}))))
+  (testing ":closed #{:foo} w/ :foo & :bar in opts throws exception"
+    (is (thrown-with-msg? #?(:clj Exception :cljs :default) #"Unknown option --bar"
+                          (cli/parse-opts ["--foo" "--bar"]
+                                          {:closed #{:foo}})))))
 
 (deftest parse-opts-collect-test
   (is (submap? '{:paths ["src" "test"]}

--- a/test/babashka/cli_test.cljc
+++ b/test/babashka/cli_test.cljc
@@ -70,24 +70,30 @@
     (is (= {:foo "bar" :baz "qux"} (cli/parse-opts ["--foo=bar" "--baz" "qux"]))))
   (testing ":closed true w/ spec allows opts & aliases in spec"
     (is (= {:foo "bar" :baz true}
-           (cli/parse-opts ["--foo=bar" "-b"]
-                           {:spec {:foo {} :baz {:alias :b}}
-                            :closed true}))))
+           (cli/parse-opts ["--foo=bar" "-b"] {:spec   {:foo {} :baz {:alias :b}}
+                                               :closed true}))))
   (testing ":closed true w/ spec throws w/ opt that is not a key nor alias in spec"
     (is (thrown-with-msg? #?(:clj Exception :cljs :default) #"Unknown option -b"
                           (cli/parse-opts ["--foo=bar" "-b"]
-                                          {:spec {:foo {}}
+                                          {:spec   {:foo {}}
                                            :closed true}))))
-  (testing ":closed #{:foo} w/ only :foo in opts is allowed"
+  (testing ":closed #{:foo} w/ only --foo in opts is allowed"
     (is (= {:foo "bar"} (cli/parse-opts ["--foo=bar"]
                                         {:closed #{:foo}}))))
-  (testing ":closed #{:foo :bar} w/ only :bar in opts is allowed"
+  (testing ":closed #{:foo :bar} w/ only --bar in opts is allowed"
     (is (= {:bar true} (cli/parse-opts ["--bar"]
                                        {:closed #{:foo :bar}}))))
-  (testing ":closed #{:foo} w/ :foo & :bar in opts throws exception"
+  (testing ":closed #{:foo} w/ --foo & --bar in opts throws exception"
     (is (thrown-with-msg? #?(:clj Exception :cljs :default) #"Unknown option --bar"
                           (cli/parse-opts ["--foo" "--bar"]
-                                          {:closed #{:foo}})))))
+                                          {:closed #{:foo}}))))
+  (testing ":closed true w/ :aliases {:f :foo} w/ only -f in opts is allowed"
+    (is (= {:foo true} (cli/parse-opts ["-f"]
+                                       {:aliases {:f :foo}
+                                        :closed  true}))))
+  (testing ":closed true w/ :coerce {:foo :long} w/ only --foo=1 in opts is allowed"
+    (is (= {:foo 1} (cli/parse-opts ["--foo=1"] {:coerce {:foo :long}
+                                                 :closed true})))))
 
 (deftest parse-opts-collect-test
   (is (submap? '{:paths ["src" "test"]}


### PR DESCRIPTION
...that throws an error when an arg is provided that isn't defined in the spec. Defaults to false to maintain current behavior.

This seem reasonable to include in here?