### PR TITLE
Add error handler function

### DIFF
--- a/API.md
+++ b/API.md
@@ -30,7 +30,7 @@ Auto-coerces `s` to data. Does not coerce when `s` is not a string.
   * is `true` or `false`, it is coerced as boolean
   * starts with number, it is coerced as a number (through `edn/read-string`)
   * starts with `:`, it is coerced as a keyword (through `parse-keyword`)
-<br><sub>[source](https://github.com/babashka/cli/blob/main/src/babashka/cli.cljc#L69-L91)</sub>
+<br><sub>[source](https://github.com/babashka/cli/blob/main/src/babashka/cli.cljc#L70-L92)</sub>
 ## `coerce`
 ``` clojure
 
@@ -42,7 +42,7 @@ Coerce string `s` using `f`. Does not coerce when `s` is not a string.
   `f` may be a keyword (`:boolean`, `:int`, `:double`, `:symbol`,
   `:keyword`) or a function. When `f` return `nil`, this is
   interpreted as a parse failure and throws.
-<br><sub>[source](https://github.com/babashka/cli/blob/main/src/babashka/cli.cljc#L93-L125)</sub>
+<br><sub>[source](https://github.com/babashka/cli/blob/main/src/babashka/cli.cljc#L94-L126)</sub>
 ## `dispatch`
 ``` clojure
 
@@ -77,14 +77,14 @@ Subcommand dispatcher.
   Each entry in the table may have additional [`parse-args`](#parse-args) options.
 
   Examples: see [README.md](README.md#subcommands).
-<br><sub>[source](https://github.com/babashka/cli/blob/main/src/babashka/cli.cljc#L477-L521)</sub>
+<br><sub>[source](https://github.com/babashka/cli/blob/main/src/babashka/cli.cljc#L497-L541)</sub>
 ## `format-opts`
 ``` clojure
 
 (format-opts {:keys [spec indent order], :or {indent 2}})
 ```
 
-<sub>[source](https://github.com/babashka/cli/blob/main/src/babashka/cli.cljc#L414-L470)</sub>
+<sub>[source](https://github.com/babashka/cli/blob/main/src/babashka/cli.cljc#L434-L490)</sub>
 ## `merge-opts`
 ``` clojure
 
@@ -93,7 +93,7 @@ Subcommand dispatcher.
 
 
 Merges babashka CLI options.
-<br><sub>[source](https://github.com/babashka/cli/blob/main/src/babashka/cli.cljc#L11-L14)</sub>
+<br><sub>[source](https://github.com/babashka/cli/blob/main/src/babashka/cli.cljc#L12-L15)</sub>
 ## `parse-args`
 ``` clojure
 
@@ -104,7 +104,7 @@ Merges babashka CLI options.
 
 Same as [`parse-opts`](#parse-opts) but separates parsed opts into `:opts` and adds
   `:cmds` and `:rest-args` on the top level instead of metadata.
-<br><sub>[source](https://github.com/babashka/cli/blob/main/src/babashka/cli.cljc#L392-L399)</sub>
+<br><sub>[source](https://github.com/babashka/cli/blob/main/src/babashka/cli.cljc#L412-L419)</sub>
 ## `parse-cmds`
 ``` clojure
 
@@ -116,7 +116,7 @@ Same as [`parse-opts`](#parse-opts) but separates parsed opts into `:opts` and a
 Parses sub-commands (arguments not starting with an option prefix) and returns a map with:
   * `:cmds` - The parsed subcommands
   * `:args` - The remaining (unparsed) arguments
-<br><sub>[source](https://github.com/babashka/cli/blob/main/src/babashka/cli.cljc#L178-L188)</sub>
+<br><sub>[source](https://github.com/babashka/cli/blob/main/src/babashka/cli.cljc#L180-L190)</sub>
 ## `parse-keyword`
 ``` clojure
 
@@ -125,7 +125,7 @@ Parses sub-commands (arguments not starting with an option prefix) and returns a
 
 
 Parse keyword from `s`. Ignores leading `:`.
-<br><sub>[source](https://github.com/babashka/cli/blob/main/src/babashka/cli.cljc#L57-L62)</sub>
+<br><sub>[source](https://github.com/babashka/cli/blob/main/src/babashka/cli.cljc#L58-L63)</sub>
 ## `parse-opts`
 ``` clojure
 
@@ -147,7 +147,8 @@ Parse the command line arguments `args`, a seq of strings.
   * `:alias` - a map of short names to long names.
   * `:spec` - a spec of options. See [spec](https://github.com/babashka/cli#spec).
   * `:restrict` - `true` or coll of keys. Throw on first parsed option not in set of keys or keys of `:spec` and `:coerce` combined.
-  * `:require` - a coll of options that are required
+  * `:require` - a coll of options that are required. See [require](https://github.com/babashka/cli#restrict).
+  * `:validate` - a map of validator functions. See [validate](https://github.com/babashka/cli#validate).
   * `:exec-args` - a map of default args. Will be overridden by args specified in `args`.
   * `:no-keyword-opts` - `true`. Support only `--foo`-style opts (i.e. `:foo` will not work).
   * `:args->opts` - consume unparsed commands and args as options
@@ -163,7 +164,7 @@ Parse the command line arguments `args`, a seq of strings.
   ;; => throws 'Unknown option --qux' exception b/c there is no :qux key in the spec
   ```
   
-<br><sub>[source](https://github.com/babashka/cli/blob/main/src/babashka/cli.cljc#L206-L390)</sub>
+<br><sub>[source](https://github.com/babashka/cli/blob/main/src/babashka/cli.cljc#L208-L410)</sub>
 ## `spec->opts`
 ``` clojure
 
@@ -172,7 +173,7 @@ Parse the command line arguments `args`, a seq of strings.
 
 
 Converts spec into opts format.
-<br><sub>[source](https://github.com/babashka/cli/blob/main/src/babashka/cli.cljc#L160-L176)</sub>
+<br><sub>[source](https://github.com/babashka/cli/blob/main/src/babashka/cli.cljc#L161-L178)</sub>
 # babashka.cli.exec 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -152,5 +152,8 @@ Initial release
 
 ## Breaking changes
 
+- Unreleased: The exception thrown on coercion failures no longer contains the
+  `:input` and `:coerce-fn` keys in its ex-data. See the "Error handling"
+  section in the README for details on the new exception format.
 - v0.2.17: The shorthand `:keywords` introduced in v0.2.16 is removed
   (breaking).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 For breaking changes, check [here](#breaking-changes).
 
+## Unreleased
+
+- Added `:error-fn` to handle errors
+- Support `:require` in specs
+
 ## v0.3.33
 
 - Added `:require` to throw on missing options

--- a/README.md
+++ b/README.md
@@ -285,6 +285,9 @@ An explanation of each key:
 - `:alias`: mapping of short name to long name.
 - `:default`: default value.
 - `:default-desc`: a string representation of the default value.
+- `:require`: `true` make this opt required.
+- `:validate`: a function used to validate the value of this opt (as described
+  in the [Validate](#validate) section).
 
 ## Help
 

--- a/README.md
+++ b/README.md
@@ -261,10 +261,10 @@ You may supply a custom error handler function with `:error-fn`. The function
 will be called with a map containing the following keys:
 - `:type` - `:org.babashka/cli` (for filtering out other types of errors).
 - `:cause` - one of:
-  - `:restricted` - a restricted option was encountered.
-  - `:missing-required` - a required option was missing.
-  - `:validation-failed` - validation failed for an option.
-  - `:coercion-failed` - coercion failed for an option.
+  - `:restrict` - a restricted option was encountered.
+  - `:require` - a required option was missing.
+  - `:validate` - validation failed for an option.
+  - `:coerce` - coercion failed for an option.
 - `:msg` - default error message.
 - `:option` - the option being parsed when the error occurred.
 

--- a/README.md
+++ b/README.md
@@ -249,6 +249,72 @@ Note that args specified in `args` will override defaults in `:exec-args`:
 ;;=> {:foo 0, :bar 42}
 ```
 
+## Error handling
+
+By default, an exception will be thrown in the following situations:
+- A restricted option is encountered
+- A required option is missing
+- Validation fails for an option
+- Coercion fails for an option
+
+You may supply a custom error handler function with `:error-fn`. The function
+will be called with a map containing the following keys:
+- `:type` - `:org.babashka/cli` (for filtering out other types of errors).
+- `:cause` - one of:
+  - `:restricted` - a restricted option was encountered.
+  - `:missing-required` - a required option was missing.
+  - `:validation-failed` - validation failed for an option.
+  - `:coercion-failed` - coercion failed for an option.
+- `:msg` - default error message.
+- `:option` - the option being parsed when the error occurred.
+
+The following keys are present depending on which error type was encountered:
+- `:type :restricted`
+  - `:restrict` - the value of the `:restrict` opt to `parse-args` (see the
+    [Restrict](#restrict) section).
+- `:type :missing-required`
+  - `:require` - the value of the `:require` opt to `parse-args` (see the
+    [Require](#require) section).
+- `:type :validation-failed`
+  - `:value` - the value of the option that failed validation.
+  - `:validate` - the value of the `:validate` opt to `parse-args` (see the
+    [Validate](#validate) section).
+- `:type :coercion-failed`
+  - `:value` - the value of the option that failed coercion.
+  - `:coerce-fn` - the coercion function used.
+
+It is recommended to either throw an exception or otherwise exit in the error
+handler function, unless you want to collect all of the errors and act on them
+in the end (see `babashka.cli-test/error-fn-test` for an example of this).
+
+For example:
+
+``` clojure
+(cli/parse-opts
+ []
+ (let [spec {:foo {:desc "You know what this is."
+             :ref "<val>"}}]
+   {:spec spec
+    :error-fn
+    (fn [{:keys [type cause msg option] :as data}]
+      (if (= :org.babashka/cli type)
+        (case cause
+          :missing-required
+          (println
+           (format "Missing required argument:\n%s"
+                   (cli/format-opts {:spec (select-keys spec [option])})))
+          (println msg))
+        (throw (ex-info msg data)))
+      (System/exit 1))}))
+```
+
+would print:
+
+```
+Missing required argument:
+  --foo <val> You know what this is.
+```
+
 ## Spec
 
 This library can work with partial information to parse options. As such, the

--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ Execution error (ExceptionInfo) at babashka.cli/parse-opts (cli.cljc:378).
 Not a positive number: 0
 ```
 
-## Adding defaults args
+## Adding default args
 
 You can supply default args with `:exec-args`:
 

--- a/src/babashka/cli.cljc
+++ b/src/babashka/cli.cljc
@@ -171,7 +171,7 @@
                          (throw (ex-info (str "Conflicting alias " alias " between " (get aliases alias) " and " k)
                                          {:alias alias})))
                        (assoc aliases alias k)))
-       require (update :require conj k)
+       require (update :require (fnil #(conj % k) #{}))
        validate (update :validate assoc k validate)
        default (update :exec-args assoc k default)))
    {}

--- a/src/babashka/cli.cljc
+++ b/src/babashka/cli.cljc
@@ -352,7 +352,7 @@
                                   (add-val acc current-opt collect-fn (coerce-coerce-fn coerce-opt) arg)
                                   (catch ExceptionInfo e
                                     (error-fn {:type :org.babashka/cli
-                                               :cause :coercion-failed
+                                               :cause :coerce
                                                :msg (.getMessage e)
                                                :option current-opt
                                                :value arg})))
@@ -376,7 +376,7 @@
        (doseq [k (keys opts)]
          (when-not (contains? restrict k)
            (error-fn {:type :org.babashka/cli
-                      :cause :restricted
+                      :cause :restrict
                       :msg (str "Unknown option: " k)
                       :restrict restrict
                       :option k}))))
@@ -384,7 +384,7 @@
        (doseq [k require]
          (when-not (find opts k)
            (error-fn {:type :org.babashka/cli
-                      :cause :missing-required
+                      :cause :require
                       :msg (str "Required option: " k)
                       :require require
                       :option k}))))
@@ -402,7 +402,7 @@
                                    (fn [{:keys [option value]}]
                                      (str "Invalid value for option " option ": " value)))]
                  (error-fn {:type :org.babashka/cli
-                            :cause :validation-failed
+                            :cause :validate
                             :msg (ex-msg-fn {:option k :value v})
                             :validate validate
                             :option k

--- a/src/babashka/cli.cljc
+++ b/src/babashka/cli.cljc
@@ -350,7 +350,7 @@
                              [(vary-meta acc assoc-in [:org.babashka/cli :args] (vec args)) current-opt nil]))
                          (recur (try
                                   (add-val acc current-opt collect-fn (coerce-coerce-fn coerce-opt) arg)
-                                  (catch ExceptionInfo e
+                                  (catch #?(:clj ExceptionInfo :cljs :default) e
                                     (error-fn {:type :org.babashka/cli
                                                :cause :coerce
                                                :msg (.getMessage e)

--- a/src/babashka/cli.cljc
+++ b/src/babashka/cli.cljc
@@ -353,7 +353,8 @@
                                   (catch #?(:clj ExceptionInfo :cljs :default) e
                                     (error-fn {:type :org.babashka/cli
                                                :cause :coerce
-                                               :msg (ex-message e)
+                                               :msg #?(:clj (.getMessage e)
+                                                       :cljs (ex-message e))
                                                :option current-opt
                                                :value arg})
                                     ;; Since we've encountered an error, don't add this opt

--- a/src/babashka/cli.cljc
+++ b/src/babashka/cli.cljc
@@ -217,7 +217,8 @@
   * `:alias` - a map of short names to long names.
   * `:spec` - a spec of options. See [spec](https://github.com/babashka/cli#spec).
   * `:restrict` - `true` or coll of keys. Throw on first parsed option not in set of keys or keys of `:spec` and `:coerce` combined.
-  * `:require` - a coll of options that are required
+  * `:require` - a coll of options that are required. See [require](https://github.com/babashka/cli#restrict).
+  * `:validate` - a map of validator functions. See [validate](https://github.com/babashka/cli#validate).
   * `:exec-args` - a map of default args. Will be overridden by args specified in `args`.
   * `:no-keyword-opts` - `true`. Support only `--foo`-style opts (i.e. `:foo` will not work).
   * `:args->opts` - consume unparsed commands and args as options

--- a/src/babashka/cli.cljc
+++ b/src/babashka/cli.cljc
@@ -355,7 +355,9 @@
                                                :cause :coerce
                                                :msg (.getMessage e)
                                                :option current-opt
-                                               :value arg})))
+                                               :value arg})
+                                    ;; Since we've encountered an error, don't add this opt
+                                    acc))
                                 (if (and (= :keywords mode)
                                          fst-colon?)
                                   nil current-opt)

--- a/src/babashka/cli.cljc
+++ b/src/babashka/cli.cljc
@@ -353,7 +353,7 @@
                                   (catch #?(:clj ExceptionInfo :cljs :default) e
                                     (error-fn {:type :org.babashka/cli
                                                :cause :coerce
-                                               :msg (.getMessage e)
+                                               :msg (ex-message e)
                                                :option current-opt
                                                :value arg})
                                     ;; Since we've encountered an error, don't add this opt

--- a/src/babashka/cli.cljc
+++ b/src/babashka/cli.cljc
@@ -161,7 +161,7 @@
   "Converts spec into opts format."
   [spec]
   (reduce
-   (fn [acc [k {:keys [coerce alias default validate]}]]
+   (fn [acc [k {:keys [coerce alias default require validate]}]]
      (cond-> acc
        coerce (update :coerce assoc k coerce)
        alias (update :alias
@@ -170,6 +170,7 @@
                          (throw (ex-info (str "Conflicting alias " alias " between " (get aliases alias) " and " k)
                                          {:alias alias})))
                        (assoc aliases alias k)))
+       require (update :require conj k)
        validate (update :validate assoc k validate)
        default (update :exec-args assoc k default)))
    {}

--- a/test/babashka/cli_test.cljc
+++ b/test/babashka/cli_test.cljc
@@ -55,7 +55,12 @@
            false
            (catch #?(:clj Exception
                      :cljs :default) e
-             (= {:input "dude", :coerce-fn :long} (ex-data e)))))
+             (= {:type :org.babashka/cli
+                 :cause :coerce
+                 :msg "Coerce failure: cannot transform input \"dude\" to long"
+                 :option :b
+                 :value "dude"}
+                (ex-data e)))))
   (is (submap? {:a [1 1]}
                (cli/parse-opts ["-a" "1" "-a" "1"] {:collect {:a []} :coerce {:a :long}})))
   (is (submap? {:foo :bar
@@ -75,11 +80,19 @@
     (is (= {:foo "bar" :baz true}
            (cli/parse-opts ["--foo=bar" "-b"] {:spec   {:foo {} :baz {:alias :b}}
                                                :restrict true}))))
-  (testing ":closed true w/ spec throws w/ opt that is not a key nor alias in spec"
-    (is (thrown-with-msg? #?(:clj Exception :cljs :default) #"Unknown option: :b"
-                          (cli/parse-opts ["--foo=bar" "-b"]
-                                          {:spec   {:foo {}}
-                                           :restrict true}))))
+  (testing ":restrict true w/ spec throws w/ opt that is not a key nor alias in spec"
+    (is (try (cli/parse-opts ["--foo=bar" "-b"]
+                             {:spec   {:foo {}}
+                              :restrict true})
+             false
+             (catch #?(:clj Exception
+                       :cljs :default) e
+               (= {:type :org.babashka/cli
+                   :cause :restrict
+                   :msg "Unknown option: :b"
+                   :option :b
+                   :restrict #{:foo}}
+                  (ex-data e))))))
   (testing ":closed #{:foo} w/ only --foo in opts is allowed"
     (is (= {:foo "bar"} (cli/parse-opts ["--foo=bar"]
                                         {:closed #{:foo}}))))
@@ -87,9 +100,17 @@
     (is (= {:bar true} (cli/parse-opts ["--bar"]
                                        {:closed #{:foo :bar}}))))
   (testing ":closed #{:foo} w/ --foo & --bar in opts throws exception"
-    (is (thrown-with-msg? #?(:clj Exception :cljs :default) #"Unknown option: :bar"
-                          (cli/parse-opts ["--foo" "--bar"]
-                                          {:closed #{:foo}}))))
+    (is (try (cli/parse-opts ["--foo" "--bar"]
+                             {:closed #{:foo}})
+             false
+             (catch #?(:clj Exception
+                       :cljs :default) e
+               (= {:type :org.babashka/cli
+                   :cause :restrict
+                   :msg "Unknown option: :bar"
+                   :option :bar
+                   :restrict #{:foo}}
+                  (ex-data e))))))
   (testing ":closed true w/ :aliases {:f :foo} w/ only -f in opts is allowed"
     (is (= {:foo true} (cli/parse-opts ["-f"]
                                        {:aliases {:f :foo}
@@ -267,13 +288,22 @@
                         (cli/parse-args ["--foo" ":bar"] {:validate {:foo #{:baz}}})))
   (is (thrown-with-msg? Exception #"Invalid value for option :foo:"
                         (cli/parse-args ["--foo" ":bar"] {:spec {:foo {:validate #{:baz}}}})))
-  (is (thrown-with-msg?
-       Exception #"Expected positive number for option :foo but got: 0"
-       (cli/parse-args
-        ["--foo" "0"]
-        {:validate {:foo {:pred pos?
-                          :ex-msg
-                          (fn
-                            [{:keys [option value]}]
-                            (str "Expected positive number for option "
-                                 option " but got: " value))}}}))))
+  (let [ex-msg-fn (fn
+                    [{:keys [option value]}]
+                    (str "Expected positive number for option "
+                         option " but got: " value))]
+    (is (try (cli/parse-args
+              ["--foo" "0"]
+              {:validate {:foo {:pred pos?
+                                :ex-msg ex-msg-fn}}})
+             false
+             (catch #?(:clj Exception
+                       :cljs :default) e
+               (= {:type :org.babashka/cli
+                   :cause :validate
+                   :msg "Expected positive number for option :foo but got: 0"
+                   :option :foo
+                   :value 0
+                   :validate {:foo {:pred pos?
+                                    :ex-msg ex-msg-fn}}}
+                  (ex-data e)))))))


### PR DESCRIPTION
As described in #35, this PR implements an `:error-fn` option to `parse-args` which is called when an error is encountered, rather than the default behaviour of throwing an error.

- Update API docs for `:error-fn`
- Add changelog entry for `:error-fn`
- Add `:error-fn` opt to `parse-args`
- Fix typo in README: "Adding default args"
- Add :require key to spec
- Add docs for :require and :validate opts to parse-args
