### PR TITLE
`auto-coerce`: Support coercing keywords with `-`

### DIFF
--- a/src/babashka/cli.cljc
+++ b/src/babashka/cli.cljc
@@ -94,7 +94,7 @@
               #?(:clj (some-> leading-num-char (Character/isDigit))
                  :cljs (not (js/isNaN s)))
               (parse-number s)
-              (and (= \: fst-char) (re-matches #"\:?[a-zA-Z0-9]+" s))
+              (and (= \: fst-char) (re-matches #"\:[a-zA-Z][a-zA-Z0-9_/\.-]*" s))
               (parse-keyword s)
               :else s))
       (catch #?(:clj Exception

--- a/test/babashka/cli_test.cljc
+++ b/test/babashka/cli_test.cljc
@@ -295,8 +295,6 @@
     (is (= :abc (cli/auto-coerce ":abc")))
     (is (= :abc-def (cli/auto-coerce ":abc-def")))
     (is (= :a/b (cli/auto-coerce ":a/b")))
-    (is (= :a/b/c (cli/auto-coerce ":a/b/c")))  ;; I'm getting weird LSP / clj-kondo output here:
-                                                ;; "single operand use of clojure.core/= is always true"
     (is (= (keyword "a/b/c") (cli/auto-coerce ":a/b/c"))) ;; but no warnings here.
     (is (= ":a.b c.d" (cli/auto-coerce ":a.b c.d")))
     (is (= ":a.b\tc.d" (cli/auto-coerce ":a.b\tc.d"))))

--- a/test/babashka/cli_test.cljc
+++ b/test/babashka/cli_test.cljc
@@ -295,7 +295,7 @@
     (is (= :abc (cli/auto-coerce ":abc")))
     (is (= :abc-def (cli/auto-coerce ":abc-def")))
     (is (= :a/b (cli/auto-coerce ":a/b")))
-    (is (= (keyword "a/b/c") (cli/auto-coerce ":a/b/c"))) ;; but no warnings here.
+    (is (= (keyword "a/b/c") (cli/auto-coerce ":a/b/c")))
     (is (= ":a.b c.d" (cli/auto-coerce ":a.b c.d")))
     (is (= ":a.b\tc.d" (cli/auto-coerce ":a.b\tc.d"))))
   (is (= -10 (cli/auto-coerce "-10")))

--- a/test/babashka/cli_test.cljc
+++ b/test/babashka/cli_test.cljc
@@ -289,8 +289,17 @@
   (testing "auto-coerce multiple keywords in keywords mode"
     (is (submap? {:foo [:bar :baz]} (cli/parse-opts [":foo" ":bar" ":foo" ":baz"] {:coerce {:foo []}}))))
   (is (= 1 (cli/auto-coerce 1)))
-  (is (= "1. This is a title." (cli/auto-coerce "1. This is a title.")))
-  (is (= ":1. This is a title." (cli/auto-coerce ":1. This is a title.")))
+  (testing (str "We want to catch most normal keywords, staying close to the Clojure reader.")
+    (is (= "1. This is a title." (cli/auto-coerce "1. This is a title.")))
+    (is (= ":1. This is a title." (cli/auto-coerce ":1. This is a title.")))
+    (is (= :abc (cli/auto-coerce ":abc")))
+    (is (= :abc-def (cli/auto-coerce ":abc-def")))
+    (is (= :a/b (cli/auto-coerce ":a/b")))
+    (is (= :a/b/c (cli/auto-coerce ":a/b/c")))  ;; I'm getting weird LSP / clj-kondo output here:
+                                                ;; "single operand use of clojure.core/= is always true"
+    (is (= (keyword "a/b/c") (cli/auto-coerce ":a/b/c"))) ;; but no warnings here.
+    (is (= ":a.b c.d" (cli/auto-coerce ":a.b c.d")))
+    (is (= ":a.b\tc.d" (cli/auto-coerce ":a.b\tc.d"))))
   (is (= -10 (cli/auto-coerce "-10")))
   (is (submap? {:foo -10} (cli/parse-opts ["--foo" "-10"])))
   (is (submap? {:foo -10} (cli/parse-opts ["--foo" "-10"] {:coerce {:foo :number}})))


### PR DESCRIPTION
New proposed behavior:

|  s           |  (auto-coerce s)  |
| ------------ | ----------------- |
|  ":abc"      |  :abc             |
|  ":abc-def"  |  :abc-def         |
|  ":a/b"      |  :a/b             |
|  ":a/b/c"    |  :a/b/c           |
|  ":a.b/d.c"  |  :a.b/d.c         |
|  ":a.b c.d"  |  ":a.b c.d"       |
