### PR TITLE
Add possibility to add a header to format-opts

### DIFF
--- a/API.md
+++ b/API.md
@@ -83,10 +83,10 @@ Subcommand dispatcher.
 ## `format-opts`
 ``` clojure
 
-(format-opts {:keys [spec indent order], :or {indent 2}})
+(format-opts {:keys [spec indent order header], :or {indent 2}})
 ```
 
-<sub>[source](https://github.com/babashka/cli/blob/main/src/babashka/cli.cljc#L481-L537)</sub>
+<sub>[source](https://github.com/babashka/cli/blob/main/src/babashka/cli.cljc#L504-L569)</sub>
 ## `merge-opts`
 ``` clojure
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -220,6 +220,5 @@ Initial release
 - Unreleased: The exception thrown on coercion failures no longer contains the
   `:input` and `:coerce-fn` keys in its ex-data. See the "Error handling"
   section in the README for details on the new exception format.
-- Unreleased: `format-opts` pads each row with trailing whitespace to the length of the longest row
 - v0.2.17: The shorthand `:keywords` introduced in v0.2.16 is removed
   (breaking).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -220,5 +220,6 @@ Initial release
 - Unreleased: The exception thrown on coercion failures no longer contains the
   `:input` and `:coerce-fn` keys in its ex-data. See the "Error handling"
   section in the README for details on the new exception format.
+- Unreleased: `format-opts` pads each row with trailing whitespace to the length of the longest row
 - v0.2.17: The shorthand `:keywords` introduced in v0.2.16 is removed
   (breaking).

--- a/README.md
+++ b/README.md
@@ -400,6 +400,15 @@ vector of vectors for the spec:
           :default-desc "src test"}]]
 ```
 
+If you need more flexibility, you can also use `opts->table`, which turns a spec into a vector of vectors, representing rows of a table.
+You can then use`format-table` to produce a table as returned by `format-opts`.
+For example to add a header row with labels for each column, you could do something like:
+
+``` clojure
+(format-table (concat [["alias" "option" "ref" "default" "description"]]
+                      (opts->table {:spec spec})))
+```
+
 ## Subcommands
 
 To handle subcommands, use

--- a/README.md
+++ b/README.md
@@ -405,9 +405,14 @@ You can then use`format-table` to produce a table as returned by `format-opts`.
 For example to add a header row with labels for each column, you could do something like:
 
 ``` clojure
-(format-table (concat [["alias" "option" "ref" "default" "description"]]
-                      (opts->table {:spec spec})))
-```
+(cli/format-table
+ {:rows (concat [["alias" "option" "ref" "default" "description"]]
+                (cli/opts->table
+                 {:spec {:foo {:alias :f, :default "yupyupyupyup", :ref "<foo>"
+                               :desc "Thingy"}
+                         :bar {:alias :b, :default "sure", :ref "<bar>"
+                               :desc "Barbarbar" :default-desc "Mos def"}}}))
+  :indent 2})```
 
 ## Subcommands
 

--- a/src/babashka/cli.cljc
+++ b/src/babashka/cli.cljc
@@ -511,22 +511,26 @@
                   (map (fn [width col] (pad width col)) widths row))]
     (map pad-row rows)))
 
-(defn format-table [rows]
+(defn format-table [{:keys [rows indent]}]
   (let [rows (pad-cells rows)
         fmt-row (fn [leader divider trailer row]
                   (str leader
                        (apply str (interpose divider row))
                        trailer))]
-    (map (fn [row]
-           #_(fmt-row "| " " | " " |" row)
-           (fmt-row "" " " "" row)) rows)))
+    (->> rows
+         (map (fn [row]
+                #_(fmt-row "| " " | " " |" row)
+                (fmt-row (apply str (repeat indent " ")) " " "" row)))
+         (map str/trimr)
+         (str/join "\n"))))
 
 (comment
   (def rows [["a" "fooo" "bara" "bazzz"  "aa"]
              ["foo" "bar" "bazzz"]
              ["fooo" "bara" "bazzz"]])
   (pad-cells rows)
-  (format-table rows))
+  (format-table {:rows rows
+                 :indent 2}))
 
 (defn opts->table [{:keys [spec order]}]
   (let [columns (set (mapcat (fn [[_ s]] (keys s)) spec))]
@@ -563,9 +567,8 @@
                            indent
                            order]
                     :or {indent 2}}]
-  (->> (format-table (opts->table cfg))
-       (map (fn [row] (str (apply str (repeat indent " ")) (str/trimr row))))
-       (str/join "\n")))
+  (format-table {:rows (opts->table cfg)
+                 :indent indent}))
 
 (defn- split [a b]
   (let [[prefix suffix] (split-at (count a) b)]

--- a/src/babashka/cli.cljc
+++ b/src/babashka/cli.cljc
@@ -549,11 +549,11 @@
 
 (comment
   (opts->table {:spec (def spec [[:pretty {:desc "Pretty-print output."
-                                  :alias :p}]
-                        [:paths {:desc "Paths of files to transform."
-                                 :coerce []
-                                 :default ["src" "test"]
-                                 :default-desc "src test"}]])})
+                                           :alias :p}]
+                                 [:paths {:desc "Paths of files to transform."
+                                          :coerce []
+                                          :default ["src" "test"]
+                                          :default-desc "src test"}]])})
   (opts->table {:spec {:foo {:alias :f, :default "yupyupyupyup", :ref "<foo>"
                              :desc "Thingy"}
                        :bar {:alias :b, :default "sure", :ref "<bar>"

--- a/src/babashka/cli.cljc
+++ b/src/babashka/cli.cljc
@@ -563,7 +563,9 @@
                            indent
                            order]
                     :or {indent 2}}]
-  (str/join "\n" (map #(str (apply str (repeat indent " ")) %) (format-table (opts->table cfg)))))
+  (->> (format-table (opts->table cfg))
+       (map (fn [row] (str (apply str (repeat indent " ")) row)))
+       (str/join "\n")))
 
 (defn- split [a b]
   (let [[prefix suffix] (split-at (count a) b)]

--- a/src/babashka/cli.cljc
+++ b/src/babashka/cli.cljc
@@ -503,13 +503,19 @@
 
 (defn pad [len s] (str s (apply str (repeat (- len (count s)) " "))))
 
-(defn format-table [rows]
+(defn pad-cells [rows]
   (let [widths (reduce
                 (fn [widths row]
                   (map max (map count row) widths)) (repeat 0) rows)
+        pad-row (fn [row]
+                  (map (fn [width col] (pad width col)) widths row))]
+    (map pad-row rows)))
+
+(defn format-table [rows]
+  (let [rows (pad-cells rows)
         fmt-row (fn [leader divider trailer row]
                   (str leader
-                       (apply str (interpose divider (map (fn [width col] (pad width col)) widths row)))
+                       (apply str (interpose divider row))
                        trailer))]
     (map (fn [row]
            #_(fmt-row "| " " | " " |" row)
@@ -519,6 +525,7 @@
   (def rows [["a" "fooo" "bara" "bazzz"  "aa"]
              ["foo" "bar" "bazzz"]
              ["fooo" "bara" "bazzz"]])
+  (pad-cells rows)
   (format-table rows))
 
 (defn opts->table [{:keys [spec order]}]

--- a/src/babashka/cli.cljc
+++ b/src/babashka/cli.cljc
@@ -564,7 +564,7 @@
                            order]
                     :or {indent 2}}]
   (->> (format-table (opts->table cfg))
-       (map (fn [row] (str (apply str (repeat indent " ")) row)))
+       (map (fn [row] (str (apply str (repeat indent " ")) (str/trimr row))))
        (str/join "\n")))
 
 (defn- split [a b]

--- a/test/babashka/cli_test.cljc
+++ b/test/babashka/cli_test.cljc
@@ -318,7 +318,17 @@
             {:spec {:foo {:alias :f, :default "yupyupyupyup", :ref "<foo>"
                           :desc "Thingy"}
                     :bar {:alias :b, :default "sure", :ref "<bar>"
-                          :desc "Barbarbar" :default-desc "Mos def"}}})))))
+                          :desc "Barbarbar" :default-desc "Mos def"}}}))))
+  (testing "header"
+    (is (= "  alias option ref   default      description\n  -f,   --foo  <foo> yupyupyupyup Thingy\n  -b,   --bar  <bar> Mos def      Barbarbar"
+           (cli/format-table
+            {:rows (concat [["alias" "option" "ref" "default" "description"]]
+                           (cli/opts->table
+                            {:spec {:foo {:alias :f, :default "yupyupyupyup", :ref "<foo>"
+                                          :desc "Thingy"}
+                                    :bar {:alias :b, :default "sure", :ref "<bar>"
+                                          :desc "Barbarbar" :default-desc "Mos def"}}}))
+             :indent 2})))))
 
 (deftest require-test
   (is (thrown-with-msg?

--- a/test/babashka/cli_test.cljc
+++ b/test/babashka/cli_test.cljc
@@ -185,10 +185,10 @@
                       :default ["src" "test"]
                       :default-desc "src test"}}]
     (is (= (str/trim "
-  -i, --from   <format> edn      The input format. <format> can be edn, json or transit. 
+  -i, --from   <format> edn      The input format. <format> can be edn, json or transit.
   -o, --to     <format> json     The output format. <format> can be edn, json or transit.
-      --paths           src test Paths of files to transform.                            
-  -p, --pretty                   Pretty-print output.                                    ")
+      --paths           src test Paths of files to transform.
+  -p, --pretty                   Pretty-print output.")
            (str/trim (cli/format-opts {:spec spec
                                        :order [:from :to :paths :pretty]}))))
     (is (= {:coerce {:from :keyword,
@@ -197,7 +197,7 @@
             :exec-args {:from :edn, :to :json, :paths ["src" "test"]}}
            (cli/spec->opts spec)))
     (is (= (str/trim "
-  -p, --pretty          Pretty-print output.        
+  -p, --pretty          Pretty-print output.
       --paths  src test Paths of files to transform.
 ") (str/trim
     (cli/format-opts {:spec [[:pretty {:desc "Pretty-print output."
@@ -313,7 +313,7 @@
 
 (deftest format-opts-test
   (testing "default width with default and default-desc"
-    (is (= "  -f, --foo <foo> yupyupyupyup Thingy   \n  -b, --bar <bar> Mos def      Barbarbar"
+    (is (= "  -f, --foo <foo> yupyupyupyup Thingy\n  -b, --bar <bar> Mos def      Barbarbar"
            (cli/format-opts
             {:spec {:foo {:alias :f, :default "yupyupyupyup", :ref "<foo>"
                           :desc "Thingy"}

--- a/test/babashka/cli_test.cljc
+++ b/test/babashka/cli_test.cljc
@@ -317,7 +317,23 @@
             {:spec {:foo {:alias :f, :default "yupyupyupyup", :ref "<foo>"
                           :desc "Thingy"}
                     :bar {:alias :b, :default "sure", :ref "<bar>"
-                          :desc "Barbarbar" :default-desc "Mos def"}}})))))
+                          :desc "Barbarbar" :default-desc "Mos def"}}}))))
+  (testing "default header"
+    (is (= "  alias   option   ref   default      description\n-------------------------------------------------\n  -f,     --foo    <foo> yupyupyupyup Thingy\n  -b,     --bar    <bar> Mos def      Barbarbar"
+           (cli/format-opts
+            {:spec {:foo {:alias :f, :default "yupyupyupyup", :ref "<foo>"
+                          :desc "Thingy"}
+                    :bar {:alias :b, :default "sure", :ref "<bar>"
+                          :desc "Barbarbar" :default-desc "Mos def"}}
+             :header true}))))
+  (testing "custom header"
+    (is (= "  short   opt   ref   default      desc     \n--------------------------------------------\n  -f,     --foo <foo> yupyupyupyup Thingy\n  -b,     --bar <bar> Mos def      Barbarbar"
+           (cli/format-opts
+            {:spec {:foo {:alias :f, :default "yupyupyupyup", :ref "<foo>"
+                          :desc "Thingy"}
+                    :bar {:alias :b, :default "sure", :ref "<bar>"
+                          :desc "Barbarbar" :default-desc "Mos def"}}
+             :header {:alias "short" :long-opt "opt" :default "default" :ref "ref" :desc "desc"}})))))
 
 (deftest require-test
   (is (thrown-with-msg?

--- a/test/babashka/cli_test.cljc
+++ b/test/babashka/cli_test.cljc
@@ -184,10 +184,11 @@
                       :coerce []
                       :default ["src" "test"]
                       :default-desc "src test"}}]
-    (is (= (str/trim "  -i, --from   <format> edn      The input format. <format> can be edn, json or transit.
+    (is (= (str/trim "
+  -i, --from   <format> edn      The input format. <format> can be edn, json or transit. 
   -o, --to     <format> json     The output format. <format> can be edn, json or transit.
-      --paths           src test Paths of files to transform.
-  -p, --pretty                   Pretty-print output.")
+      --paths           src test Paths of files to transform.                            
+  -p, --pretty                   Pretty-print output.                                    ")
            (str/trim (cli/format-opts {:spec spec
                                        :order [:from :to :paths :pretty]}))))
     (is (= {:coerce {:from :keyword,
@@ -196,7 +197,7 @@
             :exec-args {:from :edn, :to :json, :paths ["src" "test"]}}
            (cli/spec->opts spec)))
     (is (= (str/trim "
-  -p, --pretty          Pretty-print output.
+  -p, --pretty          Pretty-print output.        
       --paths  src test Paths of files to transform.
 ") (str/trim
     (cli/format-opts {:spec [[:pretty {:desc "Pretty-print output."
@@ -312,28 +313,12 @@
 
 (deftest format-opts-test
   (testing "default width with default and default-desc"
-    (is (= "  -f, --foo <foo> yupyupyupyup Thingy\n  -b, --bar <bar> Mos def      Barbarbar"
+    (is (= "  -f, --foo <foo> yupyupyupyup Thingy   \n  -b, --bar <bar> Mos def      Barbarbar"
            (cli/format-opts
             {:spec {:foo {:alias :f, :default "yupyupyupyup", :ref "<foo>"
                           :desc "Thingy"}
                     :bar {:alias :b, :default "sure", :ref "<bar>"
-                          :desc "Barbarbar" :default-desc "Mos def"}}}))))
-  (testing "default header"
-    (is (= "  alias   option   ref   default      description\n-------------------------------------------------\n  -f,     --foo    <foo> yupyupyupyup Thingy\n  -b,     --bar    <bar> Mos def      Barbarbar"
-           (cli/format-opts
-            {:spec {:foo {:alias :f, :default "yupyupyupyup", :ref "<foo>"
-                          :desc "Thingy"}
-                    :bar {:alias :b, :default "sure", :ref "<bar>"
-                          :desc "Barbarbar" :default-desc "Mos def"}}
-             :header true}))))
-  (testing "custom header"
-    (is (= "  short   opt   ref   default      desc     \n--------------------------------------------\n  -f,     --foo <foo> yupyupyupyup Thingy\n  -b,     --bar <bar> Mos def      Barbarbar"
-           (cli/format-opts
-            {:spec {:foo {:alias :f, :default "yupyupyupyup", :ref "<foo>"
-                          :desc "Thingy"}
-                    :bar {:alias :b, :default "sure", :ref "<bar>"
-                          :desc "Barbarbar" :default-desc "Mos def"}}
-             :header {:alias "short" :long-opt "opt" :default "default" :ref "ref" :desc "desc"}})))))
+                          :desc "Barbarbar" :default-desc "Mos def"}}})))))
 
 (deftest require-test
   (is (thrown-with-msg?


### PR DESCRIPTION
`(format-opts {:spec <spec> :header true})` adds a header.

You can customize the strings in the header using a map like this: `(format-opts {:spec <spec> :header {:alias "alias-header-string" :long-opt "long-opt-header-string" …}})`.

Currently the header is separated from the rows with a row of dashes. Not so sure about that.

Closes #72 
