### PR TITLE
Dispatch tree

### DIFF
--- a/src/babashka/cli.cljc
+++ b/src/babashka/cli.cljc
@@ -562,27 +562,31 @@
     (when (= prefix a)
       suffix)))
 
-(defn keyword-map [m]
-  (select-keys m (filter keyword? (keys m))))
-
 (defn table->tree [table]
   (reduce (fn [tree {:as cfg :keys [cmds]}]
             (assoc-in tree cmds (dissoc cfg :cmds)))
           {} table))
 
-(defn deep-merge [a b]
+(defn- deep-merge [a b]
   (reduce (fn [acc k] (update acc k (fn [v]
                                       (if (map? v)
                                         (deep-merge v (b k))
                                         (b k)))))
           a (keys b)))
 
+(defn- has-parse-opts? [m]
+  (some #{:spec :coerce :require :restrict :validate :args->opts :exec-args} (keys m)))
+
+(defn- is-option? [s]
+  (some-> s (str/starts-with? "-")))
+
 (defn dispatch-tree' [tree args opts]
   (loop [cmds [] all-opts {} args args cmd-info tree]
-    (let [parse-opts (deep-merge opts (keyword-map cmd-info))
-          {:keys [args opts]} (if (or (some-> (first args)
-                                              (str/starts-with? "-"))
-                                      (contains? parse-opts :args->opts))
+    (let [kwm (select-keys cmd-info (filter keyword? (keys cmd-info)))
+          should-parse-args? (or (has-parse-opts? kwm)
+                                 (is-option? (first args)))
+          parse-opts (deep-merge opts kwm)
+          {:keys [args opts]} (if should-parse-args?
                                 (parse-args args parse-opts)
                                 {:args args
                                  :opts {}})

--- a/test/babashka/cli_test.cljc
+++ b/test/babashka/cli_test.cljc
@@ -297,6 +297,8 @@
                {:cmds ["foo" "bar" "baz"]
                 :spec {:quux {:coerce :keyword}}
                 :fn identity}]]
+    (is (= "No matching command\nAvailable commands:\nfoo\n"
+           (with-out-str (cli/dispatch table []))))
     (is (= "No matching command\nAvailable commands:\nbar\n"
            (with-out-str (cli/dispatch table ["foo" "--baz" "quux"]))))
     (is (= "No matching command: baz\nAvailable commands:\nbar\n"


### PR DESCRIPTION
Expand `dispatch` to also work on a tree instead of a table.

The tree consists of nested maps with string keys for command parts and keyword keys for opts to be passed to `parse-args`.
e.g. 
```clojure
(def tree {"foo" {"bar" {"baz" {:fn identity}}}})
```
encodes a command `foo bar baz `that invokes `identity`:

```clojure
(dispatch-tree' tree ["foo" "bar" "baz"])
;=> {:cmd-info {:fn #object[clojure.core$identity 0x1f39fc08 "clojure.core$identity@1f39fc08"]}, :dispatch ["foo" "bar" "baz"], :opts {}, :args nil}
```

There can be options for `parse-args`, such as `:spec`s at every level, e.g.

```clojure
(def tree {"foo" {"bar" {"baz" {:fn identity
                                :spec {:baz-flag {:coerce :boolean}}}
                         :spec {:bar-flag {:coerce :boolean}
                                :bar-option {:coerce :keyword}}}}})

(dispatch-tree' tree ["foo" "bar" "--bar-option" "asdf" "--bar-flag" "baz" "--baz-flag"] {})
;=> {:cmd-info {:fn #object[clojure.core$identity 0x1f39fc08 "clojure.core$identity@1f39fc08"], :spec {:baz-flag {:coerce :boolean}}}, :dispatch ["foo" "bar" "baz"], :opts {:bar-option :asdf, :bar-flag true, :baz-flag true}, :args nil}
```

If there is no `:fn` key at the node that's reached by parsing the args, the dispatch will return an error:

```
(dispatch-tree' tree [] {})
;=>{:error :input-exhausted, :available-commands ("foo")}
(dispatch-tree' tree ["quux"] {})
;=>{:error :no-match, :wrong-input "quux", :available-commands ("foo")}
```

There's a `table->tree` function to convert tables to trees.