### PR TITLE
Add :require true to README spec example

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,7 +308,8 @@ For example:
 (cli/parse-opts
  []
  {:spec {:foo {:desc "You know what this is."
-         :ref "<val>"}}
+         :ref "<val>"
+         :require true}}
   :error-fn
   (fn [{:keys [spec type cause msg option] :as data}]
     (if (= :org.babashka/cli type)


### PR DESCRIPTION
Without it no error is provoked, with :require true it works as implied
by the surrounding text.
