### PR TITLE
Fix command line args for test runner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ For breaking changes, check [here](#breaking-changes).
 
 [Babashka CLI](https://github.com/babashka/cli): turn Clojure functions into CLIs!
 
+## Unreleased
+
+- Fix command line args for test runner `--dirs`, `--only`, etc
+
 ## v0.8.55 (2024-01-04)
 
 - Fix `--no-option` (`--no` prefix) in combination with subcommands

--- a/test/babashka/test_runner.clj
+++ b/test/babashka/test_runner.clj
@@ -1,11 +1,11 @@
 (ns babashka.test-runner
-  {:org.babashka/cli {:coerce {:dirs :strings
-                               :nses :symbols
-                               :patterns :strings
-                               :vars :symbols
-                               :includes :keywords
-                               :excludes :keywords
-                               :only :symbols}}}
+  {:org.babashka/cli {:coerce {:dirs [:string]
+                               :nses [:symbol]
+                               :patterns [:string]
+                               :vars [:symbol]
+                               :includes [:keyword]
+                               :excludes [:keyword]
+                               :only :symbol}}}
   (:refer-clojure :exclude [test])
   (:require
    [clojure.test :as test]


### PR DESCRIPTION
Fixes #78 

```
$ bb test --only babashka.cli-test/exec-args-replaced-test
Running tests in #{"test"}
Testing babashka.cli-test
Ran 1 tests containing 2 assertions.
0 failures, 0 errors.

$ bb test --only babashka.cli-test
Running tests in #{"test"}
Testing babashka.cli-test
Ran 15 tests containing 107 assertions.
0 failures, 0 errors.

$ bb test --vars babashka.cli-test/exec-args-replaced-test
Running tests in #{"test"}
Testing babashka.cli-test
Ran 1 tests containing 2 assertions.
0 failures, 0 errors.

$ bb test --vars babashka.cli-test/exec-args-replaced-test babashka.cli-test/error-fn-test 
Running tests in #{"test"}
Testing babashka.cli-test
Ran 2 tests containing 3 assertions.
0 failures, 0 errors.

$ bb test
Running tests in #{"test"}
Testing babashka.cli.exec-test
Testing babashka.cli-test
Ran 16 tests containing 122 assertions.
0 failures, 0 errors.
```