### PR TITLE
auto-completions for bb.cli/dispatch

### DIFF
--- a/src/babashka/cli.cljc
+++ b/src/babashka/cli.cljc
@@ -327,14 +327,14 @@
                         error-fn*))
          [opt shell cmdline] args
          _ (case opt
-             "--babashka.cli/completion-snippet"
+             "--org.babashka.cli/completion-snippet"
              (if-let [command-name (get-in opts [:completion :command])]
                (do (print-completion-shell-snippet (keyword shell) command-name)
                    (System/exit 0))
                (binding [*out* *err*]
-                 (println "Need `:completion {:command \"<name>\"}` in opts to support shell completions")
+                 (println "Need `:completion {:command \"<name>\"}` in `opts` to support shell completions")
                  (System/exit 1)))
-             "--babashka.cli/complete"
+             "--org.babashka.cli/complete"
              (do (print-opts-completions (keyword shell) opts cmdline)
                  (System/exit 0))
              :noop)
@@ -715,16 +715,16 @@
   (case type
     :bash (format "_babashka_cli_dynamic_completion()
 {
-    source <( \"$1\" --babashka.cli/complete \"bash\" \"${COMP_WORDS[*]// / }\" )
+    source <( \"$1\" --org.babashka.cli/complete \"bash\" \"${COMP_WORDS[*]// / }\" )
 }
 complete -o nosort -F _babashka_cli_dynamic_completion %s
 " program-name)
     :zsh (format "#compdef %s
-source <( \"${words[1]}\" --babashka.cli/complete \"zsh\" \"${words[*]// / }\" )
+source <( \"${words[1]}\" --org.babashka.cli/complete \"zsh\" \"${words[*]// / }\" )
 " program-name)
     :fish (format "function _babashka_cli_dynamic_completion
     set --local COMP_LINE (commandline --cut-at-cursor)
-    %s --babashka.cli/complete fish $COMP_LINE
+    %s --org.babashka.cli/complete fish $COMP_LINE
 end
 complete --command %s --no-files --arguments \"(_babashka_cli_dynamic_completion)\"
 " program-name program-name)))
@@ -818,9 +818,9 @@ complete --command %s --no-files --arguments \"(_babashka_cli_dynamic_completion
    (let [command-name (get-in opts [:completion :command])
          [opt shell cmdline] args]
      (case opt
-       "--babashka.cli/completion-snippet"
+       "--org.babashka.cli/completion-snippet"
        (print-completion-shell-snippet (keyword shell) command-name)
-       "--babashka.cli/complete"
+       "--org.babashka.cli/complete"
        (print-dispatch-completions (keyword shell) tree cmdline)
        (let [{:as res :keys [cmd-info error available-commands]}
              (dispatch-tree' tree args opts)

--- a/test/babashka/cli/completion_test.clj
+++ b/test/babashka/cli/completion_test.clj
@@ -112,10 +112,6 @@
     (is (= #{"--bar-flag"} (set (complete cmd-table ["foo" "--foo-flag" "bar" "--bar-opt" "bar-val" ""]))))))
 
 
-(deftest parse-opts-completion-test
-  (cli/parse-opts ["--babashka.cli/completion-snippet" "zsh"] {:complete true})
-  (cli/parse-opts ["--babashka.cli/complete" "zsh" "foo"] {:complete true}))
-
 (deftest dispatch-completion-test
   (is (= (slurp (io/resource "resources/completion/completion.zsh")) (with-out-str (cli/dispatch cmd-table ["--babashka.cli/completion-snippet" "zsh"] {:completion {:command "myprogram"}}))))
   (is (= (slurp (io/resource "resources/completion/completion.bash")) (with-out-str (cli/dispatch cmd-table ["--babashka.cli/completion-snippet" "bash"] {:completion {:command "myprogram"}}))))

--- a/test/babashka/cli/completion_test.clj
+++ b/test/babashka/cli/completion_test.clj
@@ -1,0 +1,95 @@
+(ns babashka.cli.completion-test
+  (:require [babashka.cli :as cli :refer [complete]]
+            [clojure.java.io :as io]
+            [clojure.test :refer :all]))
+
+(def cmd-table
+  [{:cmds ["foo"] :spec {:foo-opt {:coerece :string
+                                   :alias :f}
+                         :foo-opt2 {:coerece :string}
+                         :foo-flag {:coerce :boolean
+                                    :alias :l}}}
+   {:cmds ["foo" "bar"] :spec {:bar-opt {:coerce :keyword}
+                               :bar-flag {:coerce :boolean}}}
+   {:cmds ["bar"]}
+   {:cmds ["bar-baz"]}])
+
+(deftest completion-test
+  (testing "complete commands"
+    (is (= #{"foo" "bar" "bar-baz"} (set (complete cmd-table [""]))))
+    (is (= #{"bar" "bar-baz"} (set (complete cmd-table ["ba"]))))
+    (is (= #{"bar-baz"} (set (complete cmd-table ["bar"]))))
+    (is (= #{"foo"} (set (complete cmd-table ["f"])))))
+
+  (testing "no completions for full command"
+    (is (= #{} (set (complete cmd-table ["foo"])))))
+
+  (testing "complete subcommands and options"
+    (is (= #{"bar" "-f" "--foo-opt" "--foo-opt2" "-l" "--foo-flag"} (set (complete cmd-table ["foo" ""])))))
+
+  (testing "complete suboption"
+    (is (= #{"-f" "--foo-opt" "--foo-opt2" "-l" "--foo-flag"} (set (complete cmd-table ["foo" "-"])))))
+
+  (testing "complete short-opt"
+    (is (= #{} (set (complete cmd-table ["foo" "-f"]))))
+    (is (= #{} (set (complete cmd-table ["foo" "-f" ""]))))
+    (is (= #{} (set (complete cmd-table ["foo" "-f" "foo-val"]))))
+    (is (= #{} (set (complete cmd-table ["foo" "-f" "bar"]))))
+    (is (= #{} (set (complete cmd-table ["foo" "-f" "foo-flag"]))))
+    (is (= #{} (set (complete cmd-table ["foo" "-f" "foo-opt2"]))))
+    (is (= #{} (set (complete cmd-table ["foo" "-f" "123"]))))
+    (is (= #{} (set (complete cmd-table ["foo" "-f" ":foo"]))))
+    (is (= #{} (set (complete cmd-table ["foo" "-f" "true"]))))
+    (is (= #{"bar" "--foo-opt2" "-l" "--foo-flag"} (set (complete cmd-table ["foo" "-f" "foo-val" ""])))))
+
+  (testing "complete option with same prefix"
+    (is (= #{"--foo-opt" "--foo-opt2" "--foo-flag"} (set (complete cmd-table ["foo" "--foo"]))))
+    (is (= #{"--foo-opt2"} (set (complete cmd-table ["foo" "--foo-opt"])))))
+
+  (testing "complete long-opt"
+    (is (= #{} (set (complete cmd-table ["foo" "--foo-opt2"]))))
+    (is (= #{} (set (complete cmd-table ["foo" "--foo-opt" ""]))))
+    (is (= #{} (set (complete cmd-table ["foo" "--foo-opt" "foo-val"]))))
+    (is (= #{} (set (complete cmd-table ["foo" "--foo-opt" "bar"]))))
+    (is (= #{} (set (complete cmd-table ["foo" "--foo-opt" "foo-flag"]))))
+    (is (= #{} (set (complete cmd-table ["foo" "--foo-opt" "foo-opt2"]))))
+    (is (= #{} (set (complete cmd-table ["foo" "--foo-opt" "123"]))))
+    (is (= #{} (set (complete cmd-table ["foo" "--foo-opt" ":foo"]))))
+    (is (= #{} (set (complete cmd-table ["foo" "--foo-opt" "true"]))))
+    (is (= #{"bar" "--foo-opt2" "-l" "--foo-flag"} (set (complete cmd-table ["foo" "--foo-opt" "foo-val" ""])))))
+
+  (is (= #{"--foo-flag"} (set (complete cmd-table ["foo" "--foo-f"]))))
+
+  (testing "complete short flag"
+    (is (= #{} (set (complete cmd-table ["foo" "-l"]))))
+    (is (= #{"bar" "-f" "--foo-opt" "--foo-opt2"} (set (complete cmd-table ["foo" "-l" ""])))))
+
+  (testing "complete long flag"
+    (is (= #{} (set (complete cmd-table ["foo" "--foo-flag"]))))
+    (is (= #{"bar" "-f" "--foo-opt" "--foo-opt2"} (set (complete cmd-table ["foo" "--foo-flag" ""])))))
+
+  (is (= #{"-f" "--foo-opt" "--foo-opt2"} (set (complete cmd-table ["foo" "--foo-flag" "-"]))))
+  (is (= #{"bar"} (set (complete cmd-table ["foo" "--foo-flag" "b"]))))
+
+  (testing "complete subcommand"
+    (is (= #{"--bar-opt" "--bar-flag"} (set (complete cmd-table ["foo" "--foo-flag" "bar" ""]))))
+    (is (= #{"--bar-opt" "--bar-flag"} (set (complete cmd-table ["foo" "--foo-flag" "bar" "-"]))))
+    (is (= #{"--bar-opt" "--bar-flag"} (set (complete cmd-table ["foo" "--foo-flag" "bar" "--"]))))
+    (is (= #{"--bar-opt" "--bar-flag"} (set (complete cmd-table ["foo" "--foo-flag" "bar" "--bar-"]))))
+    (is (= #{"--bar-opt"} (set (complete cmd-table ["foo" "--foo-flag" "bar" "--bar-o"]))))
+    (is (= #{} (set (complete cmd-table ["foo" "--foo-flag" "bar" "--bar-opt" "a"]))))
+    (is (= #{"--bar-flag"} (set (complete cmd-table ["foo" "--foo-flag" "bar" "--bar-opt" "bar-val" ""]))))))
+
+
+(deftest parse-opts-completion-test
+  (cli/parse-opts ["--babashka.cli/completion-snippet" "zsh"] {:complete true})
+  (cli/parse-opts ["--babashka.cli/complete" "zsh" "foo"] {:complete true}))
+
+(deftest dispatch-completion-test
+  (is (= (slurp (io/resource "resources/completion/completion.zsh")) (with-out-str (cli/dispatch cmd-table ["--babashka.cli/completion-snippet" "zsh"] {:completion {:command "myprogram"}}))))
+  (is (= (slurp (io/resource "resources/completion/completion.bash")) (with-out-str (cli/dispatch cmd-table ["--babashka.cli/completion-snippet" "bash"] {:completion {:command "myprogram"}}))))
+  (is (= (slurp (io/resource "resources/completion/completion.fish")) (with-out-str (cli/dispatch cmd-table ["--babashka.cli/completion-snippet" "fish"] {:completion {:command "myprogram"}}))))
+
+  (is (= "compadd -- foo\n" (with-out-str (cli/dispatch cmd-table ["--babashka.cli/complete" "zsh" "myprogram f"] {:completion {:command "myprogram"}}))))
+  (is (= "COMPREPLY+=( \"foo\" )\n" (with-out-str (cli/dispatch cmd-table ["--babashka.cli/complete" "bash" "myprogram f "] {:completion {:command "myprogram"}}))))
+  (is (= "foo\n" (with-out-str (cli/dispatch cmd-table ["--babashka.cli/complete" "fish" "myprogram f "] {:completion {:command "myprogram"}})))))

--- a/test/babashka/cli/completion_test.clj
+++ b/test/babashka/cli/completion_test.clj
@@ -1,5 +1,5 @@
 (ns babashka.cli.completion-test
-  (:require [babashka.cli :as cli :refer [complete]]
+  (:require [babashka.cli :as cli :refer [complete-options complete]]
             [clojure.java.io :as io]
             [clojure.test :refer :all]))
 
@@ -13,6 +13,37 @@
                                :bar-flag {:coerce :boolean}}}
    {:cmds ["bar"]}
    {:cmds ["bar-baz"]}])
+
+(def opts {:spec {:aopt {:alias :a
+                         :coerce :string}
+                  :aopt2 {:coerce :string
+                          :validate #{"aval2"}}
+                  :bflag {:alias :b
+                          :coerce :boolean}}})
+
+(deftest complete-options-test
+  (is (= #{"--aopt" "--aopt2" "--bflag" "-b" "-a"} (set (complete-options opts [""]))))
+  (is (= #{"--aopt" "--aopt2" "--bflag" "-b" "-a"} (set (complete-options opts ["-"]))))
+  (is (= #{"--aopt" "--aopt2" "--bflag"} (set (complete-options opts ["--"]))))
+  (is (= #{"--aopt" "--aopt2"} (set (complete-options opts ["--a"]))))
+  (is (= #{"--bflag"} (set (complete-options opts ["--b"]))))
+  (is (= #{} (set (complete-options opts ["--bflag"]))))
+  (is (= #{"--aopt" "--aopt2" "-a"} (set (complete-options opts ["--bflag" ""]))))
+  (is (= #{} (set (complete-options opts ["--aopt" ""]))))
+  (is (= #{} (set (complete-options opts ["--aopt" "aval"]))))
+  (is (= #{"--aopt2" "--bflag" "-b"} (set (complete-options opts ["--aopt" "aval" ""]))))
+  (is (= #{"--aopt" "--bflag" "-b" "-a"} (set (complete-options opts ["--aopt2" "aval2" ""]))))
+  (testing "failing options"
+    (is (= #{} (set (complete-options opts ["--aopt" "-"]))))
+    (is (= #{} (set (complete-options opts ["--aopt" "--bflag"]))))
+    ;;FIXME
+    #_(is (= #{} (set (complete-options opts ["--aopt" "--bflag" ""])))))
+  (testing "invalid option value"
+    ;;FIXME
+    #_(is (= #{} (set (complete-options opts ["--aopt2" "invalid" ""])))))
+  (testing "complete option with same prefix"
+    (is (= #{"--aopt" "--aopt2"} (set (complete-options opts ["--a"]))))
+    (is (= #{"--aopt2"} (set (complete-options opts ["--aopt"]))))))
 
 (deftest completion-test
   (testing "complete commands"

--- a/test/babashka/cli/completion_test.clj
+++ b/test/babashka/cli/completion_test.clj
@@ -1,5 +1,6 @@
 (ns babashka.cli.completion-test
   (:require [babashka.cli :as cli :refer [complete-options complete]]
+            [babashka.fs :as fs]
             [clojure.java.io :as io]
             [clojure.test :refer :all]))
 
@@ -113,10 +114,11 @@
 
 
 (deftest dispatch-completion-test
-  (is (= (slurp (io/resource "resources/completion/completion.zsh")) (with-out-str (cli/dispatch cmd-table ["--babashka.cli/completion-snippet" "zsh"] {:completion {:command "myprogram"}}))))
-  (is (= (slurp (io/resource "resources/completion/completion.bash")) (with-out-str (cli/dispatch cmd-table ["--babashka.cli/completion-snippet" "bash"] {:completion {:command "myprogram"}}))))
-  (is (= (slurp (io/resource "resources/completion/completion.fish")) (with-out-str (cli/dispatch cmd-table ["--babashka.cli/completion-snippet" "fish"] {:completion {:command "myprogram"}}))))
+  (when-not (fs/windows?)
+    (is (= (slurp (io/resource "resources/completion/completion.zsh")) (with-out-str (cli/dispatch cmd-table ["--babashka.cli/completion-snippet" "zsh"] {:completion {:command "myprogram"}})))) ;
+    (is (= (slurp (io/resource "resources/completion/completion.bash")) (with-out-str (cli/dispatch cmd-table ["--babashka.cli/completion-snippet" "bash"] {:completion {:command "myprogram"}}))))
+    (is (= (slurp (io/resource "resources/completion/completion.fish")) (with-out-str (cli/dispatch cmd-table ["--babashka.cli/completion-snippet" "fish"] {:completion {:command "myprogram"}}))))
 
-  (is (= "compadd -- foo\n" (with-out-str (cli/dispatch cmd-table ["--babashka.cli/complete" "zsh" "myprogram f"] {:completion {:command "myprogram"}}))))
-  (is (= "COMPREPLY+=( \"foo\" )\n" (with-out-str (cli/dispatch cmd-table ["--babashka.cli/complete" "bash" "myprogram f "] {:completion {:command "myprogram"}}))))
-  (is (= "foo\n" (with-out-str (cli/dispatch cmd-table ["--babashka.cli/complete" "fish" "myprogram f "] {:completion {:command "myprogram"}})))))
+    (is (= "compadd -- foo\n" (with-out-str (cli/dispatch cmd-table ["--babashka.cli/complete" "zsh" "myprogram f"] {:completion {:command "myprogram"}}))))
+    (is (= "COMPREPLY+=( \"foo\" )\n" (with-out-str (cli/dispatch cmd-table ["--babashka.cli/complete" "bash" "myprogram f "] {:completion {:command "myprogram"}}))))
+    (is (= "foo\n" (with-out-str (cli/dispatch cmd-table ["--babashka.cli/complete" "fish" "myprogram f "] {:completion {:command "myprogram"}}))))))

--- a/test/babashka/cli/completion_test.clj
+++ b/test/babashka/cli/completion_test.clj
@@ -115,10 +115,10 @@
 
 (deftest dispatch-completion-test
   (when-not (fs/windows?)
-    (is (= (slurp (io/resource "resources/completion/completion.zsh")) (with-out-str (cli/dispatch cmd-table ["--babashka.cli/completion-snippet" "zsh"] {:completion {:command "myprogram"}})))) ;
-    (is (= (slurp (io/resource "resources/completion/completion.bash")) (with-out-str (cli/dispatch cmd-table ["--babashka.cli/completion-snippet" "bash"] {:completion {:command "myprogram"}}))))
-    (is (= (slurp (io/resource "resources/completion/completion.fish")) (with-out-str (cli/dispatch cmd-table ["--babashka.cli/completion-snippet" "fish"] {:completion {:command "myprogram"}}))))
+    (is (= (slurp (io/resource "resources/completion/completion.zsh")) (with-out-str (cli/dispatch cmd-table ["--org.babashka.cli/completion-snippet" "zsh"] {:completion {:command "myprogram"}})))) ;
+    (is (= (slurp (io/resource "resources/completion/completion.bash")) (with-out-str (cli/dispatch cmd-table ["--org.babashka.cli/completion-snippet" "bash"] {:completion {:command "myprogram"}}))))
+    (is (= (slurp (io/resource "resources/completion/completion.fish")) (with-out-str (cli/dispatch cmd-table ["--org.babashka.cli/completion-snippet" "fish"] {:completion {:command "myprogram"}}))))
 
-    (is (= "compadd -- foo\n" (with-out-str (cli/dispatch cmd-table ["--babashka.cli/complete" "zsh" "myprogram f"] {:completion {:command "myprogram"}}))))
-    (is (= "COMPREPLY+=( \"foo\" )\n" (with-out-str (cli/dispatch cmd-table ["--babashka.cli/complete" "bash" "myprogram f "] {:completion {:command "myprogram"}}))))
-    (is (= "foo\n" (with-out-str (cli/dispatch cmd-table ["--babashka.cli/complete" "fish" "myprogram f "] {:completion {:command "myprogram"}}))))))
+    (is (= "compadd -- foo\n" (with-out-str (cli/dispatch cmd-table ["--org.babashka.cli/complete" "zsh" "myprogram f"] {:completion {:command "myprogram"}}))))
+    (is (= "COMPREPLY+=( \"foo\" )\n" (with-out-str (cli/dispatch cmd-table ["--org.babashka.cli/complete" "bash" "myprogram f "] {:completion {:command "myprogram"}}))))
+    (is (= "foo\n" (with-out-str (cli/dispatch cmd-table ["--org.babashka.cli/complete" "fish" "myprogram f "] {:completion {:command "myprogram"}}))))))

--- a/test/babashka/cli/completion_test.clj
+++ b/test/babashka/cli/completion_test.clj
@@ -5,9 +5,9 @@
             [clojure.test :refer :all]))
 
 (def cmd-table
-  [{:cmds ["foo"] :spec {:foo-opt {:coerece :string
+  [{:cmds ["foo"] :spec {:foo-opt {:coerce :string
                                    :alias :f}
-                         :foo-opt2 {:coerece :string}
+                         :foo-opt2 {:coerce :string}
                          :foo-flag {:coerce :boolean
                                     :alias :l}}}
    {:cmds ["foo" "bar"] :spec {:bar-opt {:coerce :keyword}

--- a/test/resources/completion/completion.bash
+++ b/test/resources/completion/completion.bash
@@ -1,0 +1,5 @@
+_babashka_cli_dynamic_completion()
+{
+    source <( "$1" --babashka.cli/complete "bash" "${COMP_WORDS[*]// / }" )
+}
+complete -o nosort -F _babashka_cli_dynamic_completion myprogram

--- a/test/resources/completion/completion.bash
+++ b/test/resources/completion/completion.bash
@@ -1,5 +1,5 @@
 _babashka_cli_dynamic_completion()
 {
-    source <( "$1" --babashka.cli/complete "bash" "${COMP_WORDS[*]// / }" )
+    source <( "$1" --org.babashka.cli/complete "bash" "${COMP_WORDS[*]// / }" )
 }
 complete -o nosort -F _babashka_cli_dynamic_completion myprogram

--- a/test/resources/completion/completion.fish
+++ b/test/resources/completion/completion.fish
@@ -1,5 +1,5 @@
 function _babashka_cli_dynamic_completion
     set --local COMP_LINE (commandline --cut-at-cursor)
-    myprogram --babashka.cli/complete fish $COMP_LINE
+    myprogram --org.babashka.cli/complete fish $COMP_LINE
 end
 complete --command myprogram --no-files --arguments "(_babashka_cli_dynamic_completion)"

--- a/test/resources/completion/completion.fish
+++ b/test/resources/completion/completion.fish
@@ -1,0 +1,5 @@
+function _babashka_cli_dynamic_completion
+    set --local COMP_LINE (commandline --cut-at-cursor)
+    myprogram --babashka.cli/complete fish $COMP_LINE
+end
+complete --command myprogram --no-files --arguments "(_babashka_cli_dynamic_completion)"

--- a/test/resources/completion/completion.zsh
+++ b/test/resources/completion/completion.zsh
@@ -1,0 +1,2 @@
+#compdef myprogram
+source <( "${words[1]}" --babashka.cli/complete "zsh" "${words[*]// / }" )

--- a/test/resources/completion/completion.zsh
+++ b/test/resources/completion/completion.zsh
@@ -1,2 +1,2 @@
 #compdef myprogram
-source <( "${words[1]}" --babashka.cli/complete "zsh" "${words[*]// / }" )
+source <( "${words[1]}" --org.babashka.cli/complete "zsh" "${words[*]// / }" )


### PR DESCRIPTION
You can test it with 
```
# install test script
bbin install io.github.sohalt/bbct

# install completions

# bash
bbct --org.babashka.cli/completion-snippet bash >> ~/.bashrc

# zsh
# ~/.zsh needs to be on the $fpath variable for zsh
# if it's not, add this to your ~/.zshrc before a line with "compinit":
# fpath+=(~/.zsh)
bbct --org.babashka.cli/completion-snippet zsh > ~/.zsh/_bbct

# fish
bbct --org.babashka.cli/completion-snippet fish > ~/.config/fish/completions/bbct.fish
```