### PR TITLE
Delete mention of deprecated option from `cli/dispatch` docstring

### DIFF
--- a/src/babashka/cli.cljc
+++ b/src/babashka/cli.cljc
@@ -672,7 +672,7 @@
   Table is in the form:
 
   ```clojure
-  [{:cmds [\"sub_1\" .. \"sub_n\"] :fn f :cmds-opts [:lib]}
+  [{:cmds [\"sub_1\" .. \"sub_n\"] :fn f}
    ...
    {:cmds [] :fn f}]
   ```

--- a/src/babashka/cli.cljc
+++ b/src/babashka/cli.cljc
@@ -672,7 +672,7 @@
   Table is in the form:
 
   ```clojure
-  [{:cmds [\"sub_1\" .. \"sub_n\"] :fn f}
+  [{:cmds [\"sub_1\" .. \"sub_n\"] :fn f :args->opts [:lib]}
    ...
    {:cmds [] :fn f}]
   ```


### PR DESCRIPTION
`:cmd-opts` is deprecated in favor of `:opts->args`.
This PR updates the `cli/dispatch` docstring to use the non-deprecated form.

## References

Discussion on Slack: https://clojurians.slack.com/archives/CLX41ASCS/p1715628879976139