### PR TITLE
Undeprecate `:collect` option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ For breaking changes, check [here](#breaking-changes).
 
 [Babashka CLI](https://github.com/babashka/cli): turn Clojure functions into CLIs!
 
+## Unreleased
+
+- [#116](https://github.com/babashka/cli/issues/116): Undeprecate `:collect` option to support custom transformation of arguments to collections
+
 ## v0.8.62 (2024-12-22)
 
 - Fix [#109](https://github.com/babashka/cli/issues/109): allow options to start with a number

--- a/README.md
+++ b/README.md
@@ -208,6 +208,19 @@ Arguments that start with `--no-` arg parsed as negative flags (since 0.7.51):
 ;;=> {:colors false}
 ```
 
+### Custom collection handling
+
+Usually the above will suffice, but for custom transformation to a collection, you can use `:collect`.
+Here's an example of parsing out `,` separated multi-arg-values:
+
+``` clojure
+(cli/parse-opts ["--foo" "a,b" "--foo=c,d,e" "--foo" "f"]
+                {:collect {:foo (fn [coll arg-value]
+                                  (into (or coll [])
+                                        (str/split arg-value #",")))}})
+;; => {:foo ["a" "b" "c" "d" "e" "f"]}
+```
+
 ### Auto-coercion
 
 Since `v0.3.35` babashka CLI auto-coerces values that have no explicit coercion
@@ -430,6 +443,7 @@ An explanation of each key:
 - `:require`: `true` make this opt required.
 - `:validate`: a function used to validate the value of this opt (as described
   in the [Validate](#validate) section).
+- `:collect`: for custom collection/transformation of argument values
 
 ## Help
 

--- a/src/babashka/cli.cljc
+++ b/src/babashka/cli.cljc
@@ -282,6 +282,7 @@
   * `:exec-args` - a map of default args. Will be overridden by args specified in `args`.
   * `:no-keyword-opts` - `true`. Support only `--foo`-style opts (i.e. `:foo` will not work).
   * `:args->opts` - consume unparsed commands and args as options
+  * `:collect` - a map of collection fns. See [custom collection handling](https://github.com/babashka/cli#custom-collection-handling).
 
   Examples:
 


### PR DESCRIPTION
To support custom transformation of arguments to collections

Closes #116