### PR TITLE
Expose table->tree; include :dispatch path in flag-level error data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ For breaking changes, check [here](#breaking-changes).
 
 [Babashka CLI](https://github.com/babashka/cli): turn Clojure functions into CLIs!
 
+## Unreleased
+
+- Expose `table->tree`: converts a `dispatch` table into the nested tree used internally, handy for generating help or completions
+- `dispatch` now includes the `:dispatch` (matched subcommand path) in flag-level error data (`:restrict` / `:require` / `:validate` / `:coerce`), so an `:error-fn` can show help for the right subcommand
+
 ## v0.9.68 (2026-05-23)
 
 - [#141](https://github.com/babashka/cli/issues/141): docs: briefly cover adding production polish to a cli

--- a/src/babashka/cli.cljc
+++ b/src/babashka/cli.cljc
@@ -717,7 +717,16 @@
     (when (= prefix a)
       suffix)))
 
-(defn- table->tree [table]
+(defn table->tree
+  "Converts a `dispatch` table into a tree. Each `:cmds` becomes a path of
+  nested `:cmd` maps; other entry keys are kept on the node. Empty `:cmds`
+  merges onto the root.
+
+  ```clojure
+  (table->tree [{:cmds [\"add\"] :fn add} {:cmds [] :fn help}])
+  ;; => {:fn help, :cmd {\"add\" {:fn add}}}
+  ```"
+  [table]
   (reduce (fn [tree {:as cfg :keys [cmds]}]
             (let [ks (interleave (repeat :cmd) cmds)]
               (if (seq ks)
@@ -754,6 +763,16 @@
            should-parse-args? (or (has-parse-opts? kwm)
                                   (is-option? (first args)))
            parse-opts (deep-merge opts kwm)
+           ;; thread the current dispatch path into flag-level errors
+           ;; (restrict/require/validate/coerce) so an :error-fn can render
+           ;; help for the right subcommand
+           user-error-fn (:error-fn parse-opts)
+           parse-opts (assoc parse-opts :error-fn
+                             (fn [data]
+                               (let [data (assoc data :dispatch cmds)]
+                                 (if user-error-fn
+                                   (user-error-fn data)
+                                   (throw (ex-info (:msg data) data))))))
            {:keys [args opts]} (if should-parse-args?
                                  (parse-args args (assoc (update parse-opts :exec-args merge all-opts)
                                                          ::dispatch-tree true

--- a/test/babashka/cli_test.cljc
+++ b/test/babashka/cli_test.cljc
@@ -443,12 +443,17 @@
                 {"baz"
                  {:spec {:quux {:coerce :keyword}},
                   :fn identity}}}}}}}
-           (#'cli/table->tree [{:cmds ["foo" "bar"]
-                                :spec {:baz {:coerce :boolean}}
-                                :fn identity}
-                               {:cmds ["foo" "bar" "baz"]
-                                :spec {:quux {:coerce :keyword}}
-                                :fn identity}])))))
+           (cli/table->tree [{:cmds ["foo" "bar"]
+                              :spec {:baz {:coerce :boolean}}
+                              :fn identity}
+                             {:cmds ["foo" "bar" "baz"]
+                              :spec {:quux {:coerce :keyword}}
+                              :fn identity}]))))
+  (testing "extra entry keys (e.g. :doc) survive on the node, for help rendering"
+    (is (= {:doc "root"
+            :cmd {"foo" {:doc "a foo" :fn identity}}}
+           (cli/table->tree [{:cmds [] :doc "root"}
+                             {:cmds ["foo"] :doc "a foo" :fn identity}])))))
 
 (deftest no-keyword-opts-test (is (= {:query [:a :b :c]}
                                      (cli/parse-opts
@@ -639,6 +644,37 @@
                          :spec {:x {:coerce :boolean}}}]
                        ["foo"]
                        {:restrict true}))))
+
+(deftest dispatch-flag-error-includes-dispatch-path-test
+  (testing "flag-level errors during dispatch carry the :dispatch path so an
+            :error-fn can render help for the right subcommand"
+    ;; capture the first error and halt (mirrors a real error-fn that exits)
+    (let [capture (fn [table args opts]
+                    (let [err (atom nil)]
+                      (try
+                        (cli/dispatch table args
+                                      (assoc opts :error-fn
+                                             (fn [e] (reset! err e)
+                                               (throw (ex-info "stop" {})))))
+                        (catch #?(:clj Exception :cljs :default) _ nil))
+                      @err))
+          table [{:cmds [] :spec {:g {:coerce :boolean}}}
+                 {:cmds ["foo"] :fn identity :spec {:x {:coerce :boolean}}}
+                 {:cmds ["foo" "bar"] :fn identity :spec {:y {:coerce :boolean}}}]]
+      (testing ":restrict at top level -> empty :dispatch"
+        (let [e (capture table ["--bogus"] {:restrict true})]
+          (is (= :restrict (:cause e)))
+          (is (= [] (:dispatch e)))))
+      (testing ":restrict at nested subcommand -> full :dispatch path"
+        (let [e (capture table ["foo" "bar" "--bogus"] {:restrict true})]
+          (is (= :restrict (:cause e)))
+          (is (= ["foo" "bar"] (:dispatch e)))))
+      (testing ":require error also carries :dispatch path"
+        (let [e (capture [{:cmds ["foo"] :fn identity
+                           :spec {:req {:require true}}}]
+                         ["foo"] {})]
+          (is (= :require (:cause e)))
+          (is (= ["foo"] (:dispatch e))))))))
 
 (deftest issue-106-test
   (d/deflet


### PR DESCRIPTION
Make table->tree public (with docstring) so help/completions can be generated from a dispatch table.

dispatch now threads the matched subcommand path into flag-level error data (:restrict / :require / :validate / :coerce), so an :error-fn can render help for the right subcommand level instead of the root.