### PR TITLE
doc: changelog: breaking changes: update version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -326,7 +326,7 @@ Initial release
 
 ## Breaking changes
 
-- Unreleased: The exception thrown on coercion failures no longer contains the
+- v0.3.35: The exception thrown on coercion failures no longer contains the
   `:input` and `:coerce-fn` keys in its ex-data. See the "Error handling"
   section in the README for details on the new exception format.
 - v0.2.17: The shorthand `:keywords` introduced in v0.2.16 is removed


### PR DESCRIPTION
Noticed an old stale `Unreleased` under Breaking Changes. Tracked down actual version and updated.