### PR TITLE
subcommands -> commands + doc review

### DIFF
--- a/API.md
+++ b/API.md
@@ -148,7 +148,7 @@ Function.
 Command dispatcher.
 
   Dispatches on longest matching command entry in `table` by matching
-  commands to the `:cmds` vector and invoking the correspondig `:fn`.
+  commands to the `:cmds` vector and invoking the corresponding `:fn`.
 
   Table is in the form:
 

--- a/API.md
+++ b/API.md
@@ -1,19 +1,19 @@
 # Table of contents
 -  [`babashka.cli`](#babashka.cli) 
-    -  [`*exit-fn*`](#babashka.cli/*exit-fn*) - Terminates the process after <code>dispatch</code>'s <code>:help</code> option prints an *error* (unknown/missing subcommand, flag error).
+    -  [`*exit-fn*`](#babashka.cli/*exit-fn*) - Terminates the process after <code>dispatch</code>'s <code>:help</code> option prints an *error* (unknown/missing command, option error).
     -  [`apply-defaults`](#babashka.cli/apply-defaults) - Fills missing keys in <code>m</code> from defaults.
     -  [`auto-coerce`](#babashka.cli/auto-coerce) - Auto-coerces <code>s</code> to data.
     -  [`coerce`](#babashka.cli/coerce) - Coerce string <code>s</code> using <code>f</code>.
     -  [`coerce-opts`](#babashka.cli/coerce-opts) - Coerces values in the map <code>m</code> using the provided configuration.
     -  [`default-width-fn`](#babashka.cli/default-width-fn) - The default <code>:max-width-fn</code> for [<code>format-table</code>](#babashka.cli/format-table)/[<code>format-opts</code>](#babashka.cli/format-opts).
-    -  [`dispatch`](#babashka.cli/dispatch) - Subcommand dispatcher.
-    -  [`format-command-error`](#babashka.cli/format-command-error) - Render a terse, helpful message (a string) for a dispatch error, given the data <code>dispatch</code> passes to its <code>:error-fn</code>: * <code>:no-match</code> (unknown subcommand) -> message + commands + hint * <code>:input-exhausted</code> (group, no subcommand) -> message + commands + hint * flag error (<code>:restrict</code> / <code>:require</code> / <code>:validate</code> / <code>:coerce</code>) -> message + usage + hint Reads the command tree, <code>:prog</code>, <code>:inherit</code>, <code>:dispatch</code> (the path), and for flag errors <code>:msg</code> (and for <code>:no-match</code>, <code>:wrong-input</code>) from the data.
-    -  [`format-command-help`](#babashka.cli/format-command-help) - Render conventional <code>--help</code> text (a string) for the command at path <code>cmds</code> in a <code>dispatch</code> table or tree: <code></code>` Usage: <prog> [options] <command> <description> ; the entry's :doc (first line, then the rest) Commands: ; child commands with their one-line :doc ...
-    -  [`format-opts`](#babashka.cli/format-opts)
-    -  [`format-table`](#babashka.cli/format-table)
+    -  [`dispatch`](#babashka.cli/dispatch) - Command dispatcher.
+    -  [`format-command-error`](#babashka.cli/format-command-error) - Render a terse, helpful message (a string) for a dispatch error.
+    -  [`format-command-help`](#babashka.cli/format-command-help) - Render conventional <code>--help</code> text (a string) for the command at path <code>cmds</code> in a <code>dispatch</code> table or tree.
+    -  [`format-opts`](#babashka.cli/format-opts) - Formats options into an options usage help string.
+    -  [`format-table`](#babashka.cli/format-table) - Formats <code>rows</code> into a table (string).
     -  [`merge-opts`](#babashka.cli/merge-opts) - Merges babashka CLI options.
     -  [`number-char?`](#babashka.cli/number-char?)
-    -  [`opts->table`](#babashka.cli/opts->table)
+    -  [`opts->table`](#babashka.cli/opts->table) - Converts options to a table of rows.
     -  [`parse-args`](#babashka.cli/parse-args) - Same as [<code>parse-opts</code>](#babashka.cli/parse-opts) with return data reshaped.
     -  [`parse-cmds`](#babashka.cli/parse-cmds) - Parses sub-commands (arguments not starting with an option prefix).
     -  [`parse-keyword`](#babashka.cli/parse-keyword) - Parse keyword from <code>s</code>.
@@ -41,12 +41,12 @@
 Function.
 
 Terminates the process after `dispatch`'s `:help` option prints an *error*
-  (unknown/missing subcommand, flag error). `--help`/`-h` is not an error - it
+  (unknown/missing command, option error). `--help`/`-h` is not an error - it
   prints help and returns, so it does not call this. Called with a map:
 
   * `:exit` - exit code (always non-zero, `1`)
-  * `:cause` - the dispatch error cause: `:no-match` (unknown subcommand),
-    `:input-exhausted` (group with no subcommand), or the flag cause
+  * `:cause` - the dispatch error cause: `:no-match` (unknown command),
+    `:input-exhausted` (no command or incomplete multi-word command), or the option cause
     (`:restrict` / `:require` / `:validate` / `:coerce`)
   * `:dispatch` - the command path
   * `:data` - the original `dispatch` error data
@@ -62,7 +62,7 @@ Terminates the process after `dispatch`'s `:help` option prints an *error*
   Must exit or throw.
 
   Default: `System/exit` (JVM), `js/process.exit` (Node), `throw` (browser).
-<p><sub><a href="https://github.com/babashka/cli/blob/main/src/babashka/cli.cljc#L1581-L1608">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/cli/blob/main/src/babashka/cli.cljc#L1591-L1618">Source</a></sub></p>
 
 ## <a name="babashka.cli/apply-defaults">`apply-defaults`</a>
 ``` clojure
@@ -117,7 +117,7 @@ Coerces values in the map `m` using the provided configuration.
 
   Supported options:
   * `:coerce` - a map of option (keyword) names to type keywords (optionally wrapped in a collection).
-  * `:spec` - a spec of options. See [spec](https://github.com/babashka/cli#spec).
+  * `:spec` - a spec of options. See [spec](/README.md#spec).
   * `:error-fn` - error handler, called with a map containing `:cause` (`:coerce`), `:msg`, `:option`, `:value`, `:opts`, and `:flag` (when the option was typed).
 
   `:flag` is the literal option token as it appeared on the command line (e.g.
@@ -146,10 +146,10 @@ The default `:max-width-fn` for [`format-table`](#babashka.cli/format-table)/[`f
 ```
 Function.
 
-Subcommand dispatcher.
+Command dispatcher.
 
   Dispatches on longest matching command entry in `table` by matching
-  subcommands to the `:cmds` vector and invoking the correspondig `:fn`.
+  commands to the `:cmds` vector and invoking the correspondig `:fn`.
 
   Table is in the form:
 
@@ -170,7 +170,7 @@ Subcommand dispatcher.
                      :cmd {"clean" {:fn clean-cache}}}}}
   ```
 
-  The subcommands render in help and completions in the order specified. Map literals with
+  The commands render in help and completions in the order specified. Map literals with
   more than 8 entries lose insertion order, so put a `:cmd-order` (vector of
   child command names) on the map to control which children are shown and in
    what order (like `:order` does for options). A table keeps its entry order
@@ -185,7 +185,7 @@ Subcommand dispatcher.
 
   Use an empty `:cmds` vector to always match or to provide global options.
 
-  For a single-command CLI (no subcommands), use a one-entry table whose `:cmds`
+  For a single-command CLI (no commands), use a one-entry table whose `:cmds`
   is `[]`:
 
   ```clojure
@@ -199,7 +199,7 @@ Subcommand dispatcher.
 
   * `--help`/`-h` print help for the command they precede and return (no error,
     so the process ends with status 0). This goes through a `:help-fn`.
-  * an unknown/missing subcommand or a flag error prints a terse message and
+  * an unknown/missing command or a option error prints a terse message and
     exits non-zero (via [`*exit-fn*`](#babashka.cli/*exit-fn*)). This goes through the `:error-fn`.
 
   Both default handlers can be overridden: pass your own `:help-fn` (called with
@@ -209,8 +209,8 @@ Subcommand dispatcher.
 
   Each entry in the table may have additional [`parse-args`](#babashka.cli/parse-args) options.
 
-  For more information and examples, see [README.md](README.md#subcommands).
-<p><sub><a href="https://github.com/babashka/cli/blob/main/src/babashka/cli.cljc#L1894-L1982">Source</a></sub></p>
+  For more information and examples, see [README.md](README.md#commands).
+<p><sub><a href="https://github.com/babashka/cli/blob/main/src/babashka/cli.cljc#L1904-L1992">Source</a></sub></p>
 
 ## <a name="babashka.cli/format-command-error">`format-command-error`</a>
 ``` clojure
@@ -218,23 +218,23 @@ Subcommand dispatcher.
 ```
 Function.
 
-Render a terse, helpful message (a string) for a dispatch error, given the
-  data `dispatch` passes to its `:error-fn`:
+Render a terse, helpful message (a string) for a dispatch error.
+  It is given the data `dispatch` passes to its `:error-fn`:
 
-  * `:no-match` (unknown subcommand) -> message + commands + hint
-  * `:input-exhausted` (group, no subcommand) -> message + commands + hint
-  * flag error (`:restrict` / `:require` / `:validate` / `:coerce`) -> message
+  * `:no-match` (unknown command) -> message + commands + hint
+  * `:input-exhausted` (no command or incomplete multi-word command) -> message + commands + hint
+  *  option error (`:restrict` / `:require` / `:validate` / `:coerce`) -> message
     + usage + hint
 
   Reads the command tree, `:prog`, `:inherit`, `:dispatch` (the path), and for
-  flag errors `:msg` (and for `:no-match`, `:wrong-input`) from the data.
-  Messages name the flag as typed (`--foo`/`-x`), not `:foo`.
+  option errors `:msg` (and for `:no-match`, `:wrong-input`) from the data.
+  Messages name the option as typed (`--foo`/`-x`), not `:foo`.
 
   This is the renderer the `:help` option's default `:error-fn` uses (it prints
   this, then calls [`*exit-fn*`](#babashka.cli/*exit-fn*)). Call it from a custom `:error-fn` to keep the
   standard message and add your own output. `--help`/`-h` is not an error - it
   goes to the `:help-fn`, rendered by [`format-command-help`](#babashka.cli/format-command-help).
-<p><sub><a href="https://github.com/babashka/cli/blob/main/src/babashka/cli.cljc#L1619-L1666">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/cli/blob/main/src/babashka/cli.cljc#L1629-L1676">Source</a></sub></p>
 
 ## <a name="babashka.cli/format-command-help">`format-command-help`</a>
 ``` clojure
@@ -243,7 +243,7 @@ Render a terse, helpful message (a string) for a dispatch error, given the
 Function.
 
 Render conventional `--help` text (a string) for the command at path `cmds`
-  in a `dispatch` table or tree:
+  in a `dispatch` table or tree.
 
   ```
   Usage: <prog> [options] <command>
@@ -279,14 +279,18 @@ Render conventional `--help` text (a string) for the command at path `cmds`
   This is the renderer the `:help` option uses; call it from a custom `:help-fn`
   to render the standard help and then add your own output. An entry may carry
   `:no-doc true` to be omitted from `Commands:`.
-<p><sub><a href="https://github.com/babashka/cli/blob/main/src/babashka/cli.cljc#L1538-L1579">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/cli/blob/main/src/babashka/cli.cljc#L1548-L1589">Source</a></sub></p>
 
 ## <a name="babashka.cli/format-opts">`format-opts`</a>
 ``` clojure
 (format-opts {:as cfg, :keys [indent wrap max-width-fn], :or {indent 2, wrap true, max-width-fn default-width-fn}})
 ```
 Function.
-<p><sub><a href="https://github.com/babashka/cli/blob/main/src/babashka/cli.cljc#L897-L904">Source</a></sub></p>
+
+Formats options into an options usage help string.
+
+  See [Printing options](/README.md#printing-options).
+<p><sub><a href="https://github.com/babashka/cli/blob/main/src/babashka/cli.cljc#L903-L914">Source</a></sub></p>
 
 ## <a name="babashka.cli/format-table">`format-table`</a>
 ``` clojure
@@ -296,7 +300,10 @@ Function.
   :as cfg})
 ```
 Function.
-<p><sub><a href="https://github.com/babashka/cli/blob/main/src/babashka/cli.cljc#L792-L811">Source</a></sub></p>
+
+Formats `rows` into a table (string).
+  See [Printing options](/README.md#printing-options).
+<p><sub><a href="https://github.com/babashka/cli/blob/main/src/babashka/cli.cljc#L792-L814">Source</a></sub></p>
 
 ## <a name="babashka.cli/merge-opts">`merge-opts`</a>
 ``` clojure
@@ -319,7 +326,10 @@ Function.
 (opts->table {:keys [spec order columns]})
 ```
 Function.
-<p><sub><a href="https://github.com/babashka/cli/blob/main/src/babashka/cli.cljc#L841-L861">Source</a></sub></p>
+
+Converts options to a table of rows.
+  See [Printing options](/README.md#printing-options).
+<p><sub><a href="https://github.com/babashka/cli/blob/main/src/babashka/cli.cljc#L844-L867">Source</a></sub></p>
 
 ## <a name="babashka.cli/parse-args">`parse-args`</a>
 ``` clojure
@@ -343,7 +353,7 @@ Same as [`parse-opts`](#babashka.cli/parse-opts) with return data reshaped.
 Function.
 
 Parses sub-commands (arguments not starting with an option prefix). Returns a map with:
-  * `:cmds` - The parsed subcommands
+  * `:cmds` - The parsed commands
   * `:args` - The remaining (unparsed) arguments
 <p><sub><a href="https://github.com/babashka/cli/blob/main/src/babashka/cli.cljc#L200-L210">Source</a></sub></p>
 
@@ -372,15 +382,15 @@ Returns a map of options parsed from command line arguments `args`, a seq of str
   Supported `opts`:
   * `:coerce` - a map of option (keyword) names to type keywords (optionally wrapped in a collection.)
   * `:alias` - a map of short names to long names.
-  * `:spec` - a spec of options. See [spec](https://github.com/babashka/cli#spec).
+  * `:spec` - a spec of options. See [spec](/README.md#spec).
   * `:restrict` - `true` or coll of keys. Throw on first parsed option not in set of keys or keys of `:spec` and `:coerce` combined.
-  * `:require` - a coll of options that are required. See [require](https://github.com/babashka/cli#restrict).
-  * `:validate` - a map of validator functions. See [validate](https://github.com/babashka/cli#validate).
+  * `:require` - a coll of options that are required. See [require](/README.md#restrict).
+  * `:validate` - a map of validator functions. See [validate](/README.md#validate).
   * `:exec-args` - a map of default args. Will be overridden by args specified in `args`. Values from `:exec-args` are NOT coerced or auto-coerced; provide them in their final form. Not subject to `:restrict`.
   * `:no-keyword-opts` - `true`. Support only `--foo`-style opts (i.e. `:foo` will not work).
   * `:repeated-opts` - `true`. Forces writing the option name for every value, e.g. `--foo a --foo b`, rather than `--foo a b`
   * `:args->opts` - consume unparsed commands and args as options
-  * `:collect` - a map of collection fns. See [custom collection handling](https://github.com/babashka/cli#custom-collection-handling).
+  * `:collect` - a map of collection fns. See [custom collection handling](/README.md#custom-collection-handling).
 
   Examples:
 
@@ -443,7 +453,7 @@ Converts a `dispatch` table into a tree. Each `:cmds` becomes a path of
   ```
 
   A tree passed in is normalized and returned, so the function is idempotent.
-<p><sub><a href="https://github.com/babashka/cli/blob/main/src/babashka/cli.cljc#L1065-L1087">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/cli/blob/main/src/babashka/cli.cljc#L1075-L1097">Source</a></sub></p>
 
 ## <a name="babashka.cli/validate-opts">`validate-opts`</a>
 ``` clojure

--- a/API.md
+++ b/API.md
@@ -198,7 +198,7 @@ Command dispatcher.
 
   * `--help`/`-h` print help for the command they precede and return (no error,
     so the process ends with status 0). This goes through a `:help-fn`.
-  * an unknown/missing command or a option error prints a terse message and
+  * an unknown/missing command or an option error prints a terse message and
     exits non-zero (via [`*exit-fn*`](#babashka.cli/*exit-fn*)). This goes through the `:error-fn`.
 
   Both default handlers can be overridden: pass your own `:help-fn` (called with

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ For breaking changes, check [here](#breaking-changes).
 
 [Babashka CLI](https://github.com/babashka/cli): turn Clojure functions into CLIs!
 
+## Unreleased
+
+- [#161](https://github.com/babashka/cli/issues/161), [#163](https://github.com/babashka/cli/issues/163): docs: review and update.
+Nomenclature change: subcommand->command.
+For babashka cli library users, we used the term "subcommand".
+For users of clis created with babashka cli we use the term "command".
+They are the same thing.
+We now use the term "command" for both audiences.
+([@lread](https://github.com/lread))
+
 ## v0.11.72 (2026-06-11)
 
 - [#131](https://github.com/babashka/cli/issues/131): Exclude `scratch.clj` from released jar

--- a/README.md
+++ b/README.md
@@ -290,7 +290,7 @@ Boolean flags are assumed by default, like so:
 But you can explicitly specify `:boolean` coercion (and will sometimes need to, see [Arguments](#arguments)):
 
 ``` clojure
-(cli/parse-opts ["--verbose"] {:spec {:coerce :boolean}})
+(cli/parse-opts ["--verbose"] {:spec {:verbose {:coerce :boolean}}})
 ;;=> {:verbose true}
 
 (cli/parse-opts ["-v" "-v" "-v"] {:spec {:verbose {:alias :v :coerce [:boolean]}}})

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Clojars Project](https://img.shields.io/clojars/v/org.babashka/cli.svg)](https://clojars.org/org.babashka/cli)
 [![bb built-in](https://raw.githubusercontent.com/babashka/babashka/master/logo/built-in-badge.svg)](https://book.babashka.org#badges)
 
-Turn Clojure functions into CLIs! This library can be used from:
+Turn Clojure functions into Command Line Interfaces! This library can be used from:
 - [babashka](https://github.com/babashka/babashka) - included as a built-in library
 - [Clojure on the JVM](https://www.clojure.org/guides/install_clojure) - we support Clojure 1.10.3 and above on Java 11 and above
 - [ClojureScript](https://clojurescript.org) - we test against the current release
@@ -12,39 +12,49 @@ Turn Clojure functions into CLIs! This library can be used from:
 
 ## Status
 
-This library is still in design phase and may still undergo breaking changes.
+This library is still in the design phase and may still undergo breaking changes.
 Check [breaking changes](CHANGELOG.md#breaking-changes) before upgrading!
 
 ## Installation
 
-Add to your `deps.edn` or `bb.edn` `:deps` entry:
+For Clojure and ClojureScript, include a `:deps` entry in your  `deps.edn` file:
 
 ``` clojure
 org.babashka/cli {:mvn/version "<latest-version>"}
 ```
 
+For babashka, no changes are needed; `org.babashka/cli` is a babashka built-in library.
+
 ## Intro
 
-Turn a Clojure function into a CLI that takes Unix-style command line arguments:
+Turn a Clojure function into a CLI that takes Unix-style command line arguments. E.g.:
 
 ``` clojure
-$ cli command --long-opt1 v1 -o v2
+$ prog command --flag --long-opt1 v1 -o v2 arg
 ```
+
+Where:
+- `prog` is your program (which will be launched by Clojure, ClojureScript, or babashka)
+- `command` is a single or multi-word command for your program
+- `--flag` is a boolean flag option
+- `--long-opt1 v1` is an option
+- `-o v2` is a short option
+- `arg` is a positional argument
 
 The main ideas:
 
-- Put as little effort as possible into turning a clojure function into a CLI,
-  similar to `-X` style invocations. For lazy people like me! If you are not
+- Put as little effort as possible into turning a Clojure function into a CLI,
+  similar to `-X` exec style invocations. For lazy people like me! If you are not
   familiar with `clj -X`, read the docs
   [here](https://clojure.org/reference/clojure_cli#use_fn).
-- But with a better UX by not having to use quotes on the command line as a
+- But with a better user experience by not having to use quotes on the command line as a
   result of having to pass EDN directly: `--dir foo` instead of `:dir '"foo"'` (or
-  who knows how to write the latter in `cmd.exe` or Powershell?).
-- By default, employ an open world assumption: passing extra arguments does not break and arguments
-  can be re-used in multiple contexts.
-- But also support incremental restrictions and validations as a form of polishing a CLI for production use.
+  who knows how to write the latter in Windows' `cmd.exe` or Powershell?).
+- By default, employ an open world assumption: passing extra arguments does not break, and arguments
+  can be reused in multiple contexts.
+- But also support incremental restrictions and validations as a way to polish a CLI for production use.
 
-See [clojure CLI](#clojure-cli) for how to turn your exec functions into CLIs.
+See [clojure CLI](#clojure-cli) for how to turn your `-X` exec functions into CLIs.
 
 ## Projects using babashka CLI
 
@@ -60,7 +70,7 @@ See [clojure CLI](#clojure-cli) for how to turn your exec functions into CLIs.
 - [Simple example](#simple-example)
 - [Options](#options)
 - [Arguments](#arguments)
-- [Subcommands](#subcommands)
+- [Commands](#commands)
 - [Completions](#completions)
 - [Adding Production Polish](#adding-production-polish)
 - [Babashka tasks](#babashka-tasks)
@@ -69,8 +79,8 @@ See [clojure CLI](#clojure-cli) for how to turn your exec functions into CLIs.
 
 ## Simple example
 
-Babashka CLI works in Clojure, ClojureScript and [babashka](https://book.babashka.org/).
-Here is an example babashka script to get you started!
+Babashka CLI works in Clojure, ClojureScript, and [babashka](https://book.babashka.org/).
+Here is an example babashka script to get you started! Save it to `try-me.clj`.
 
 ```clojure
 #!/usr/bin/env bb
@@ -104,13 +114,22 @@ Here is an example babashka script to get you started!
 (apply -main *command-line-args*)
 ```
 
-In the above example, `:help true` wires up automatic `--help`/`-h` support and terse error messages for you. See [Subcommands > Help](#help) for
-customizing it.
+The `:help true` option supplied to `dispatch` wires up automatic `--help`/`-h` support and terse error messages (as opposed to thrown exceptions) for you.
 
-The first argument to `dispatch` is a [tree](#tree-format) of subcommands. Since this CLI has no subcommands, this is all you need to write. See [Subcommands](#subcommands) for more info.
+Let's request usage help:
+```
+$ bb try-me.clj --help
+Usage: try-me [options]
 
-And this is how you run it:
+Options:
+  -n, --num  Number of some items (required)
+  -d, --dir  Directory name to do stuff
+      --flag I am just a flag
+  -h, --help Show this help
+```
+See [Commands > Help](#help) to customize help.
 
+Let's try running with some options:
 ```
 $ bb try-me.clj --num 1 --dir my_dir --flag
 Error: Directory does not exist: my_dir
@@ -119,25 +138,18 @@ Usage: try-me [options]
 
 Run "try-me --help" for more information.
 ```
+The directory was validated with `dir-exists?`. Because the directory does not exist, you see the custom error message produced by the `:ex-msg` function.
 
-The directory is validated with `dir-exists?`. A custom error message is
-produced by the `:ex-msg` function. Since the dir does not exist, let's create
-it and try again.
-
+Let's create `my_dir`, then try again:
 ```
 $ mkdir my_dir
 $ bb try-me.clj --num 1 --dir my_dir --flag
 Here are your cli args!: {:num 1, :dir my_dir, :flag true}
+```
+All validations passed, and the `run` function was invoked.
 
-$ bb try-me.clj --help
-Usage: try-me [options]
-
-Options:
-  -n, --num   Number of some items (required)
-  -d, --dir   Directory name to do stuff
-      --flag  I am just a flag
-  -h, --help  Show this help
-
+The `:num` option includes `:require true`, let's see what happens when we don't include it on the command line:
+```
 $ bb try-me.clj
 Error: Required option: --num
 
@@ -145,28 +157,33 @@ Usage: try-me [options]
 
 Run "try-me --help" for more information.
 ```
+We, appropriately, get a terse error message and an exit status of 1.
 
-### Adding subcommands
+### Adding commands
 
-To add subcommands to this CLI, we need to specify a subcommand structure. We'll just give an example here. See [Subcommands](#subcommands) for more info.
+To add commands to this CLI, we need to specify a command structure. We'll just give an example here. See [Commands](#commands) for more info.
 
+Alter `try-me.clj`:
 ``` clojure
+;; same as above
 (defn run [{:keys [opts]}]
   (println "Here are your cli args!:" opts))
 
+;; new
 (defn version [_]
   (println "try-me 1.0"))
 
+;; new
 (def tree
   {:cmd {"run"     {:fn run     :doc "Run the thing" :spec spec}
          "version" {:fn version :doc "Print version"}}})
 
+;; updated to use `tree` command structure
 (defn -main [& args]
   (cli/dispatch tree args {:prog "try-me" :help true}))
 ```
 
-`--help` now lists the commands:
-
+`--help` now lists the available commands:
 ```
 $ bb try-me.clj --help
 Usage: try-me [options] <command>
@@ -181,20 +198,29 @@ Options:
 Run "try-me <command> --help" for more information on a command.
 ```
 
-`bb try-me.clj run --num 1 --flag` calls `run`; `bb try-me.clj version` calls
-`version`. See [Subcommands](#subcommands) for shared options, inheritance and
-help customization.
+The `run` command calls the `run` function:
+```
+$ bb try-me.clj run --num 1 --flag
+Here are your cli args!: {:num 1, :flag true}
+```
+
+The `version` command calls the `version` function:
+```
+$ bb try-me.clj version
+try-me 1.0
+```
+
+See [Commands](#commands) for shared options, inheritance, and help customization.
 
 ## Options
 
-For parsing options, use either [`parse-opts`](/API.md#parse-opts) or [`parse-args`](/API.md#parse-args).
+If you'd like to parse options yourself (instead of using [`dispatch`](/API.md#dispatch)),
+use either lower-level [`parse-opts`](/API.md#parse-opts) or [`parse-args`](/API.md#parse-args). We will
+use these parse functions in this section to demonstrate how options parsing works.
 
-On the command line, a named option is written `--opt val`, or `-o val` using an
-[alias](#aliases). Babashka CLI also accepts a `:`-prefixed form, `:opt val`, to
-match the Clojure CLI `-X` invocation style. The two cannot be mixed in a single
-invocation. Use `--`/`-` or `:`, not both.
+On the command line, a named option is written as `--opt val` or short-form [alias](#aliases) `-o val`.
 
-Options are configured with a [spec](#spec) (short for "options spec", not
+Options are configured with a [spec](#spec) (short for "options specification", not
 `clojure.spec`): a map keyed by option name, each value a map of `:coerce`,
 `:alias`, `:validate`, `:require`, `:desc`, etc., passed under `:spec`:
 
@@ -236,28 +262,38 @@ Coerce values into a collection:
 ;;=> {:paths ["src" "test"]}
 ```
 
-Transforming to a collection of a certain type:
+Transforming into a collection of a certain type:
 
 ``` clojure
 (cli/parse-opts ["--foo" "bar" "--foo" "baz"] {:spec {:foo {:coerce [:keyword]}}})
 ;; => {:foo [:bar :baz]}
 ```
 
-Besides the built-in coercion keywords, `:coerce` accepts any function (called
-with the string value):
+In addition to the built-in coercion keywords, `:coerce` accepts any function (called
+with the option's value as a string):
 
 ``` clojure
 (cli/parse-opts ["--letter" "alpha"] {:spec {:letter {:coerce (fn [s] (subs s 0 1))}}})
 ;;=> {:letter "a"}
 ```
 
-Booleans need no explicit `true` value and `:coerce` option:
+Boolean flags are assumed by default, like so:
 
 ``` clojure
 (cli/parse-opts ["--verbose"])
 ;;=> {:verbose true}
 
 (cli/parse-opts ["-v" "-v" "-v"] {:spec {:verbose {:alias :v :coerce []}}})
+;;=> {:verbose [true true true]}
+```
+
+But you can explicitly specify `:boolean` coercion (and will sometimes need to, see [Arguments](#arguments)):
+
+``` clojure
+(cli/parse-opts ["--verbose"] {:spec {:coerce :boolean}})
+;;=> {:verbose true}
+
+(cli/parse-opts ["-v" "-v" "-v"] {:spec {:verbose {:alias :v :coerce [:boolean]}}})
 ;;=> {:verbose [true true true]}
 ```
 
@@ -275,22 +311,38 @@ Flags may be combined into a single short option:
 ;;=> {:a true :b true :c true}
 ```
 
-Arguments that start with `--no-` arg parsed as negative flags:
+Long options that start with `--no-` are parsed as negative flags:
 
 ``` clojure
 (cli/parse-opts ["--no-colors"])
 ;;=> {:colors false}
 ```
-
 This works for any option. For a boolean option where the negation is meaningful,
 set `:negatable true` in its spec to advertise it in help as `--[no-]colors`.
 
-## Spec
 
-A spec (short for "options spec", not `clojure.spec`) is a map keyed by option
+Babashka CLI also accepts a `:`-prefixed form, `:opt val`, to
+match the Clojure CLI `-X` invocation style. The two forms cannot be mixed in a single
+invocation. Use `--`/`-` or `:`, not both. If you prefer to only allow only `--`/`-` style options, specify `:no-keyword-opts true`:
+
+```clojure
+(cli/parse-args [":foo" "bar"])
+;; => {:opts {:foo "bar"}}
+
+(cli/parse-args [":foo" "bar"] {:no-keyword-opts true})
+;; => {:args [":foo" "bar"], :opts {}}
+
+(cli/parse-args ["--foo" "bar" ":no" "mixing"])
+;; => {:args [":no" "mixing"], :opts {:foo "bar"}}
+```
+Notice how unrecognized options are considered [Arguments](#arguments).
+
+### Spec
+
+A spec (short for options specification, not `clojure.spec`) is a map keyed by option
 name; each value configures one option.
-Alongside the parsing keys (`:coerce`, `:alias`, `:validate`, ...) it carries
-`:desc` and `:ref`, used when printing options (see [Printing options](#printing-options)). For
+Alongside the parsing keys (`:coerce`, `:alias`, `:validate`, ...), it carries
+`:desc`, `:ref`, and `:default-desc` used when printing options (see [Printing options](#printing-options)). For
 example:
 
 ``` clojure
@@ -314,22 +366,23 @@ example:
                     :default-desc "src test"}})
 ```
 
-You can pass the spec to `parse-opts` under the `:spec` key: `(parse-opts args {:spec spec})`.
+You can pass the spec to `parse-opts` under the `:spec` key: `(parse-opts args {:spec spec})`, or when using
+`dispatch`, in the entry for each command.
 An explanation of each key:
 
-- `:ref`: a name which can be used as a reference in the description (`:desc`)
+- `:ref`: a name that describes the option value, which is typically used as a reference in the description (`:desc`)
 - `:desc`: a description of the option.
 - `:coerce`: coerce a string value to a type. Built-in keywords: `:boolean`
   (`:bool`), `:int` (`:long`), `:double`, `:number`, `:symbol`, `:keyword`,
   `:string`, `:edn`, `:auto`. A collection collects repeated values: `[]`
-  (vector), `#{}` (set) or `()` (list); put a coercion keyword inside it to
-  coerce each element (e.g. `[:keyword]`, `#{:int}`). A function is also
-  accepted: it is called with the string and returns the value.
-- `:alias`: mapping of short name to long name.
+  (vector), `#{}` (set) or `()` (list); put a coercion keyword inside the collection to
+  coerce each element (e.g., `[:keyword]`, `#{:int}`). A function is also
+  accepted: it is called with the option value as a string and returns the coerced value.
+- `:alias`: an alternative short name; a synonym for the option name.
 - `:default`: default value.
 - `:default-desc`: a string representation of the default value.
 - `:require`: `true` make this opt required.
-- `:validate`: a function used to validate the value of this opt (as described
+- `:validate`: a function used to validate the value of this option (as described
   in the [Validate](#validate) section).
 - `:collect`: collect repeated values into a collection (`[]` vector, `#{}` set
   or `()` list), or a function `(fn [coll arg-value] ...)` for custom collection
@@ -337,7 +390,7 @@ An explanation of each key:
 
 ### Custom collection handling
 
-Usually the above will suffice, but for custom transformation to a collection, you can use `:collect`.
+For those rare cases when you need it, you can use a `:collect` function for custom collection.
 Here's an example of parsing out `,` separated multi-arg-values:
 
 ``` clojure
@@ -352,13 +405,28 @@ Here's an example of parsing out `,` separated multi-arg-values:
 
 Babashka CLI auto-coerces values that have no explicit coercion
 with [`auto-coerce`](/API.md#auto-coerce):
-it automatically tries to convert booleans, numbers and keywords.
+It automatically tries to convert booleans, numbers, and keywords.
+
+``` clojure
+(cli/parse-opts ["--num" "1339" "--kw" ":foo" "--bool" "false" "--str" "bar"])
+;; => {:num 1339, :kw :foo, :bool false, :str "bar"}
+
+;; the actual types...:
+(->> (cli/parse-opts ["--num" "1339" "--kw" ":foo" "--bool" "false" "--str" "bar"])
+     (reduce-kv (fn [m k v]
+               (assoc m k [v (type v)]))
+             {}))
+;; => {:num [1339 java.lang.Long],
+;;     :kw [:foo clojure.lang.Keyword],
+;;     :bool [false java.lang.Boolean],
+;;     :str ["bar" java.lang.String]}
+```
 
 ### Aliases
 
-An `:alias` specifies a mapping from short to long name.
+An `:alias` specifies a synonym short option name for the option name.
 
-The library can distinguish aliases with characters in common, so a way to implement the common `-v`/`-vv` unix pattern is:
+Babashka CLI distinguishes aliases with characters in common, so a way to implement the common `-v`/`-vv` Unix pattern is:
 ``` clojure
 (def spec {:verbose      {:alias :v
                           :desc  "Enable verbose output."}
@@ -390,7 +458,7 @@ user=> (cli/parse-opts ["-vvv"] {:spec spec})
 ## Arguments
 
 To parse positional arguments, you can use `parse-args` and/or the `:args->opts`
-option. E.g. to parse arguments for the `git push` command:
+option. E.g., to parse arguments for the `git push` command:
 
 ``` clojure
 (cli/parse-args ["--force" "ssh://foo"] {:spec {:force {:coerce :boolean}}})
@@ -400,7 +468,7 @@ option. E.g. to parse arguments for the `git push` command:
 ;;=> {:args ["ssh://foo"], :opts {:force true}}
 ```
 
-Note that this library can only disambiguate correctly between values for
+Note that babashka CLI can only disambiguate correctly between values for
 options and trailing arguments with enough `:coerce` information
 available. Without the `:coerce :boolean` info, we get:
 
@@ -433,7 +501,7 @@ To fold positional arguments into the parsed options, you can use `:args->opts`:
 ;;=> {:url "ssh://foo", :force true}
 ```
 
-If you want to fold a variable amount of arguments, you can coerce into a vector
+If you want to fold a variable number of arguments, you can coerce them into a vector
 and specify the variable number of arguments with `repeat`:
 
 ``` clojure
@@ -445,59 +513,102 @@ and specify the variable number of arguments with `repeat`:
 Options may be interspersed with the positional arguments:
 
 ``` clojure
-(def cli-opts {:spec {:bar {:coerce []} :force {:coerce :boolean}}
+(def cli-opts {:spec {:foo {:coerce :keyword}
+                      :bar {:coerce []}
+                      :force {:coerce :boolean}}
                :args->opts (cons :foo (repeat :bar))})
+
 (cli/parse-opts ["arg1" "arg2" "--force" "arg3"] cli-opts)
-;;=> {:foo "arg1", :bar ["arg2" "arg3"], :force true}
+;; => {:foo :arg1, :bar ["arg2" "arg3"], :force true}
 ```
 
-This also holds for a subcommand leaf in [dispatch](#subcommands): a command with
-variadic `:args->opts` parses options before, among or after its positional
-arguments. Without `:args->opts`, `dispatch` stops at the first positional (to
-route subcommands), so trailing options would not be parsed.
+This also holds for a command leaf in [dispatch](#commands): a command with
+variadic `:args->opts` parses options before, among, or after its positional
+arguments. Without `:args->opts`, `dispatch` stops at the first positional argument
+(to route commands), so trailing options would not be parsed.
 
-## Subcommands
+## Commands
 
-To handle subcommands, use
-[dispatch](/API.md#dispatch).
+Babashka CLI handles commands with [dispatch](/API.md#dispatch).
 
-Say we want a CLI called as:
+### Single-word Commands
+
+Say we want a CLI with a `copy` command, a `delete` command, and an undocumented `debug` command:
 
 ```
 $ example copy <file> --dry-run
 $ example delete <file> --recursive --depth 3
+$ example debug
 ```
 
-``` clojure
-(ns example
+Commands can be specified in two ways: as a tree or a table.
+The difference is more apparrent for [Multi-word Commands](#multi-word-commands).
+We'll use the tree structure for this example, save it to `try_cmds.clj`.
+
+```clojure
+(ns try-cmds
   (:require [babashka.cli :as cli]))
 
 (defn copy [{:keys [opts]}]
   (prn :copy opts))
 
 (defn delete [{:keys [opts]}]
-  (prn :delete opts))
 
+(def tree
+  {:cmd {"copy"   {:fn copy :doc "Copy a file\nMore details here" :args->opts [:file]
+                   :spec {:dry-run {:coerce :boolean :desc "Do a dry run"}}}
+         "delete" {:fn delete :doc "Delete a file" :args->opts [:file]
+                   :spec {:recursive {:coerce :boolean :desc "Recurse"}
+                          :depth     {:coerce :long    :desc "Max depth"}}}
+         "debug"  {:fn prn :doc "Dump internal state"}}
+   ;; specify which commands to show and in what order (we exclude hidden debug command)
+   :cmd-order ["copy" "delete"]}])
+
+(defn -main [& args]
+  (cli/dispatch tree args {:prog "try-cmds" :help true}))
+```
+
+The same command structure expressed as a table is:
+
+```clojure
 (def table
-  [{:cmds ["copy"]   :fn copy   :doc "Copy a file" :args->opts [:file]
+  [{:cmds ["copy"]   :fn copy   :doc "Copy a file\nMore details here" :args->opts [:file]
     :spec {:dry-run {:coerce :boolean :desc "Do a dry run"}}}
    {:cmds ["delete"] :fn delete :doc "Delete a file" :args->opts [:file]
     :spec {:recursive {:coerce :boolean :desc "Recurse"}
            :depth     {:coerce :long    :desc "Max depth"}}}
+   ;; hide debug command from usage help and completions with :no-doc
    {:cmds ["debug"]  :fn prn    :doc "Dump internal state" :no-doc true}])
 
 (defn -main [& args]
-  (cli/dispatch table args {:prog "example" :help true}))
+  (cli/dispatch table args {:prog "try-cmds" :help true}))
 ```
+The order of the entries in the table does not matter when matching commands, but it is used for `--help`.
 
-Run it with `clojure -M -m example ...` or `bb -m example ...`. `dispatch`
-matches the longest `:cmds` path in the args and calls that entry's `:fn` with
-the parsed result. `:help true` wires up `--help`/`-h` and terse errors (see
-[Help](#help)):
+Regardless of tree or table format, each command entry accepts any [parse-args](#options) option (`:spec`,
+`:args->opts`, `:alias`, `:restrict`, ...).
+
+> [!NOTE]
+> If you want to try `try_cmd.clj`  from your terminal:
+>
+> - For babashka, create `bb.edn` in the same dir:
+>     ```clojure
+>     {:paths ["."]}
+>     ```
+>   Then run with `bb -m try-cmds ...` (Our examples below use babashka).
+>
+> - For Clojure, create a `deps.edn` in the same dir:
+>     ```clojure
+>     {:paths ["."]  :deps {org.babashka/cli {:mvn/version "<latest-version>"}}}
+>     ```
+>   Then run with `clojure -M -m try-cmds ...`
+
+`dispatch` matches the given command line args against specified commands and calls the matching entry's `:fn` with the parsed result.
+`:help true` wires up `--help`/`-h` and prints terse errors instead of throwing exceptions (see [Help](#help)):
 
 ```
-$ example --help
-Usage: example [options] <command>
+$ bb -m try-cmds --help
+Usage: try-cmds [options] <command>
 
 Commands:
   copy   Copy a file
@@ -506,67 +617,259 @@ Commands:
 Options:
   -h, --help Show this help
 
-Run "example <command> --help" for more information on a command.
+Run "try-cmds <command> --help" for more information on a command.
 ```
 
-The `Commands:` summaries above come from each entry's `:doc`, a string
-documenting that (sub)command. Its first line is shown in the parent's command
-list. The `debug` command is absent from that list because `:no-doc true` hides a
-command from `--help` and from completions. The same `:no-doc true` on a spec
-option hides that option the same way. The option still parses, so it works for
-deprecated or internal flags. The full text of `:doc` is shown as
-the description on the command's own `--help` output, between the usage line and
-`Options:`:
+The `Commands:` descriptions come from each command entry's `:doc` key.
+The first line of `:doc` is used as a summary for the command.
+
+The `debug` command is absent in the help because it is absent from `:cmd-order` (it was suppressed in table format via `:no-doc true`). This also hides `debug` from [completions](#completions).
+
+> [!TIP]
+> Like `:cmd-order`, options can be hidden with `:order`.
+> And `:no-doc true` can also be used on an option to hide it.
+> Hiding works well for deprecated or internal commands and options.
+
+The full text of `:doc` is shown as the description on the command's `--help` output, between the usage line and `Options:`:
 
 ```
-$ example copy --help
-Usage: example copy [options] <file>
+$ bb -m try-cmds copy --help
+Usage: try-cmds copy [options] <file>
 
 Copy a file
+More details here
 
 Options:
       --dry-run  Do a dry run
   -h, --help     Show this help
 ```
 
-Running `example copy the-file --dry-run` calls `copy`, which prints:
+Running `bb -m try-cmds copy the-file --dry-run` calls `copy`, which prints:
 
 ``` clojure
 :copy {:file "the-file", :dry-run true}
 ```
 
-The `:fn` is called with a map of the parsed result:
+The `copy` command entry `:fn` is called with a map of the parsed result:
 
 - `:opts`: the parsed options (`{:file "the-file" :dry-run true}`; `:file` comes
   from `:args->opts`)
-- `:dispatch`: the matched command path (`["copy"]`)
+- `:dispatch`: the matched command path `["copy"]` from the given `dispatch` command structure.
 - `:args`: any leftover positional args (`nil` here)
 
-An unknown or missing subcommand prints a terse message and exits 1:
+An unknown or missing command prints a terse message and exits the process with a status of 1:
 
 ```
-$ example bogus
+$ bb -m try-cmds bogus
 Unknown command: bogus
 
 Commands:
-  copy
-  delete
+  copy   Copy a file
+  delete Delete a file
 
-Run "example --help" for more information.
+Run "try-cmds --help" for more information.
 ```
 
-See [neil](https://github.com/babashka/neil) for a real-world CLI using subcommands.
+### Multi-word Commands
 
-Each table entry accepts any [parse-args](#options) option (`:spec`,
-`:args->opts`, `:alias`, `:restrict`, ...). The order of entries in the table
-doesn't matter for invocation on the command line, but is used for `--help`
-output and completions.
+Sometimes a command can be made up of multiple words.
+Think of `git`, for example. We have `git remote`, `git remote add ...`, `git remote delete ...`, etc.
 
-### Tree format
+The command hierarchy is:
+- `remote` (level 1) is a parent of both:
+  - `remote add` (level 2)
+  - `remote delete` (level 2)
 
-Subcommands can also be specified in a tree format. The root accepts a `:spec`
-for top-level options. The first level of subcommands is specified under `:cmd`
-in a map of strings to subcommand options, which are the same as in the table
+A `dispatch` tree might be expressed as:
+```clojure
+{:cmd {"remote"
+       {:fn remotes-list :doc "show list of remotes"
+        :cmd {"add"   {:fn remote-add    :doc "add a new remote"}
+              "delete" {:fn remote-delete :doc "delete a remote"}}
+        :cmd-order ["add" "delete"]}}}
+```
+
+The same commands, expressed as a `dispatch` table:
+```clojure
+[{:cmds ["remote"]          :fn remotes-list  :doc "show list of remotes"}
+ {:cmds ["remote" "add"]    :fn remote-add    :doc "add a new remote"}
+ {:cmds ["remote" "delete"] :fn remote-delete :doc "delete a remote"}]
+```
+
+Multi-word commands are matched from the command line in the specified order, and the longest matching entry's `:fn` is called.
+So `git remote add` would result in a call to the `remote-add` `:fn` and not the `remotes-list` `:fn`.
+
+A command line can have options before and between commands and command hierarchy levels.
+
+Root-level options are specified in the root spec.
+A contrived example to illustrate:
+
+``` clojure
+(def root-spec {:foo {:coerce #(str "global-" %)}})
+(def level1-spec {:bar {:coerce #(str "sub1-" %)}})
+(def level2-spec {:baz {:coerce #(str "sub2-" %)}})
+
+(def tree
+  {:spec root-spec
+   :cmd {"sub1" {:fn identity :spec sub1-spec
+                 :cmd {"sub2" {:fn identity :spec sub2-spec}}}}})
+
+(cli/dispatch tree ["--foo" "a" "sub1" "--bar" "b" "sub2" "--baz" "c" "arg"])
+;; => {:dispatch ["sub1" "sub2"],
+;;     :opts {:foo "global-a", :bar "sub1-b", :baz "sub2-c"},
+;;     :args ["arg"]}
+```
+
+<details>
+<summary>For reference, the equivalent command table structure:</summary>
+
+```clojure
+(def table
+  [{:cmds [] :spec root-spec} ;; root spec specified with `:cmds []`
+   {:cmds ["sub1"] :fn identity :spec sub1-spec}
+   {:cmds ["sub1" "sub2"] :fn identity :spec sub2-spec}])
+```
+</details>
+
+Specs are not merged across command hierarchy levels.
+An option is parsed with the spec of the current matching command (while parsing the command line from left to right):
+- `--foo a` appears before any matching command, so is coerced with `root-spec`
+- `--bar b` appears after a matching `sub1` but before `sub2`, so is coerced with `sub1`'s `sub1-spec`
+- `--baz c` appears after matching `sub1` and `sub2`, so is coerced with `sub2`s `sub2-spec`
+
+Let's compare with a different ordering on the command line:
+```clojure
+(cli/dispatch tree ["--foo" "a" "sub1" "sub2" "--bar" "b" "--baz" "c" "arg"])
+;; => {:dispatch ["sub1" "sub2"],
+;;     :opts {:foo "global-a", :bar "b", :baz "sub2-c"},
+;;     :args ["arg"]}
+```
+Notice that `--bar` is now after `sub1` and `sub2` and gets default string coercion treatment.
+This is because it was processed with `sub2-spec`, which has no specific coercion for `:bar`.
+
+Let's explore how `:restrict` works with command hierarchies.
+``` clojure
+(def tree
+  {:cmd {"group"
+         {:spec {:registry {}}
+          :cmd {"sub"
+                {:fn identity :spec {:format {}}}}}}})
+```
+<details>
+<summary>Equivalent table syntax</summary>
+
+```clojure
+(def table
+  [{:cmds ["group"]       :spec {:registry {}}}
+   {:cmds ["group" "sub"] :fn identity :spec {:format {}}}])
+```
+</details>
+
+Because `:registry` belongs to the `group` command, it is expected only to be used with the `group` command:
+```clojure
+(cli/dispatch tree ["group" "--registry" "X" "sub"] {:restrict true})
+;; => {:dispatch ["group" "sub"], :opts {:registry "X"}, :args nil}
+```
+and not the `group sub` command:
+```clojure
+(cli/dispatch tree ["group" "sub" "--registry" "X"] {:restrict true})
+;; throws: Unknown option: --registry
+```
+
+Mark an option with `:inherit true` to also accept it at any command hierarchy descendant level.
+The option is coerced and restrict-checked wherever it appears:
+``` clojure
+(def tree
+  {:cmd {"group"
+         {:spec {:registry {:inherit true}} ;; <--
+          :cmd {"sub"
+                {:fn identity :spec {:format {}}}}}}})
+
+(cli/dispatch tree ["group" "sub" "--registry" "X"] {:restrict true})
+;; => {:dispatch ["group" "sub"], :opts {:registry "X"}, :args nil}
+```
+
+<details>
+<summary>Equivalent table syntax</summary>
+
+```clojure
+(def table
+  [{:cmds ["group"]       :spec {:registry {:inherit true}}} ;; <--
+   {:cmds ["group" "sub"] :fn identity :spec {:format {}}}])
+```
+</details>
+
+A descendant command may redefine an option in its own spec, in which case the descendant's spec wins.
+
+Instead of marking individual options, you can pass an `:inherit` option to `dispatch`.
+Specify `true` to inherit all options, or a set of keys to inherit only those options:
+
+``` clojure
+(def tree
+  {:cmd {"group"
+         {:spec {:registry {}}
+          :cmd {"sub"
+                {:fn identity :spec {:format {}}}}}}})
+
+(cli/dispatch tree ["group" "sub" "--registry" "X"] {:inherit true})
+;; => {:dispatch ["group" "sub"], :opts {:registry "X"}, :args nil}
+(cli/dispatch tree ["group" "sub" "--registry" "X"] {:inherit #{:registry}})
+;; => {:dispatch ["group" "sub"], :opts {:registry "X"}, :args nil}
+```
+
+You can use `:args->opts`, but command matching is always prioritized first:
+``` clojure
+(def tree
+  {:cmd {"sub1"
+         {:fn identity :spec sub1-spec :args->opts [:some-opt]
+          :cmd {"sub2"
+                {:fn identity :spec sub2-spec}}}}})
+
+(cli/dispatch tree ["sub1" "dude"])
+;; => {:dispatch ["sub1"], :opts {:some-opt "dude"}, :args nil}
+(cli/dispatch tree ["sub1" "sub2"])
+;; => {:dispatch ["sub1" "sub2"], :opts {}, :args nil}
+```
+
+<details>
+<summary>Equivalent table syntax</summary>
+
+```clojure
+(def table
+  [{:cmds ["sub1"] :fn identity :spec sub1-spec :args->opts [:some-opt]}
+   {:cmds ["sub1" "sub2"] :fn identity :spec sub2-spec}])
+```
+</details>
+
+See [neil](https://github.com/babashka/neil) for a real-world CLI using multi-word commands.
+
+### Command formats
+Commands can be specified in a tree or table format.
+Both formats are supported; use the format that best suits you.
+
+The difference between formats becomes apparent when multi-word commands are used.
+For example, let's say we have a CLI with commands:
+- `copy` (hierarchy level 1)
+- `cache` (hierarchy level 1)
+- `cache clean` (hierarchy level 2)
+
+The table format represents this structure flatly:
+
+```clojure
+(def table
+  [{:cmds [] :spec {:verbose {coerce :boolean :inherit true :desc "Verbose output"}}} ;; top-level options
+   {:cmds ["copy"] :fn copy :doc "Copy a file" :args->opts [:file]
+                   :spec {:dry-run {:coerce :boolean :desc "Do a dry run"}}}
+   {:cmds ["cache" :doc "Manage the cache"]}
+   {:cmds ["cache clean"] :fn clean :doc "Clean the cache"}])
+
+(cli/dispatch table args {:prog "example" :help true})
+```
+
+The tree format, as you would guess, uses nesting.
+The root accepts a `:spec` for top-level options.
+The first level of commands is specified under `:cmd`
+in a map of strings to command options, which are the same as in the table
 above, minus the `:cmds` entry. You can nest arbitrarily deep.
 
 ``` clojure
@@ -575,6 +878,7 @@ above, minus the `:cmds` entry. You can nest arbitrarily deep.
    :cmd {"copy" {:fn copy :doc "Copy a file" :args->opts [:file]
                  :spec {:dry-run {:coerce :boolean :desc "Do a dry run"}}}
          "cache" {:doc "Manage the cache"
+                  ;; clean is nested under cache
                   :cmd {"clean" {:fn clean :doc "Clean the cache"}}}}})
 
 (cli/dispatch tree args {:prog "example" :help true})
@@ -583,10 +887,10 @@ above, minus the `:cmds` entry. You can nest arbitrarily deep.
 The table or tree format can be used interchangeably in `dispatch`,
 `format-command-help` and the like.
 
-The map's order is used for help output. This can be problematic with more than
-8 entries since those maps turn into unordered hash-maps. In that case you can
-use `:cmd-order` to specify the order for printing. Commands not mentioned in
-`:cmd-order` are left out of printed output, but are still callable on the
+You'll want consistent ordering for help output.
+The tree format uses a map; the nature of Clojure maps is that they become unordered hash-maps after 8 entries.
+You probably don't want to rely on this implementation detail and can explicitly control order with `:cmd-order`.
+Commands not mentioned in `:cmd-order` are left out of printed output, but are still callable on the
 command line.
 
 ``` clojure
@@ -595,148 +899,114 @@ command line.
        "cache" {...}}}
 ```
 
-Options can be supplied at each level, before and between the subcommands. The
-root level (`:cmds []`) holds options available to every command. For example:
-
-``` clojure
-(def global-spec {:foo {:coerce :keyword}})
-(def sub1-spec {:bar {:coerce :keyword}})
-(def sub2-spec {:baz {:coerce :keyword}})
-
-(def table
-  [{:cmds [] :spec global-spec}
-   {:cmds ["sub1"] :fn identity :spec sub1-spec}
-   {:cmds ["sub1" "sub2"] :fn identity :spec sub2-spec}])
-
-(cli/dispatch table ["--foo" "a" "sub1" "--bar" "b" "sub2" "--baz" "c" "arg"])
-
-;;=>
-
-{:dispatch ["sub1" "sub2"],
- :opts {:foo :a, :bar :b, :baz :c},
- :args ["arg"]}
-```
-
-It is possible to use `:args->opts`, but subcommands are always prioritized over
-arguments:
-
-``` clojure
-(def table
-  [{:cmds ["sub1"] :fn identity :spec sub1-spec :args->opts [:some-opt]}
-   {:cmds ["sub1" "sub2"] :fn identity :spec sub2-spec}])
-
-(cli/dispatch table ["sub1" "dude"]) ;;=> {:dispatch ["sub1"], :opts {:some-opt "dude"}}
-(cli/dispatch table ["sub1" "sub2"]) ;;=> {:dispatch ["sub1" "sub2"], :opts {}}
-```
-
-Specs are not merged across levels: an option is parsed with the spec of the
-level it appears at, so it must be supplied before its subcommand. With
-`:restrict`, supplying it after the subcommand is an error:
-
-``` clojure
-(def table
-  [{:cmds ["group"]       :spec {:registry {}}}
-   {:cmds ["group" "sub"] :fn identity :spec {:format {}}}])
-
-(cli/dispatch table ["group" "--registry" "X" "sub"] {:restrict true})
-;;=> {:dispatch ["group" "sub"], :opts {:registry "X"}}
-
-(cli/dispatch table ["group" "sub" "--registry" "X"] {:restrict true})
-;; throws: Unknown option: --registry
-```
-
-Mark an option with `:inherit true` to also accept it at any descendant level (after
-the subcommand). It is coerced and restrict-checked wherever it appears:
-
-``` clojure
-(def table
-  [{:cmds ["group"]       :spec {:registry {:inherit true}}}
-   {:cmds ["group" "sub"] :fn identity :spec {:format {}}}])
-
-(cli/dispatch table ["group" "sub" "--registry" "X"] {:restrict true})
-;;=> {:dispatch ["group" "sub"], :opts {:registry "X"}}
-```
-
-A descendant may redefine it in its own spec, in which case the descendant's
-definition wins.
-
-Instead of marking individual options, pass `:inherit` to `dispatch`: `true` to
-inherit all options, or a set of keys to inherit only those:
-
-``` clojure
-(cli/dispatch table ["group" "sub" "--registry" "X"] {:inherit true})
-(cli/dispatch table ["group" "sub" "--registry" "X"] {:inherit #{:registry}})
-```
-
 ### Help
 
 Pass `:help true` to `dispatch` (and `:prog`, the program name) to add help to a
-CLI, no `:restrict` needed:
+CLI:
 
 ``` clojure
-(cli/dispatch table args {:prog "example" :help true})
+(cli/dispatch tree args {:prog "some-prog" :help true})
 ```
 
-- `--help`/`-h` print help for the command in front of them and return (the
-  process ends with status 0). So `example deps outdated --help` shows help for
-  `deps outdated`.
-- A mistyped or missing subcommand prints a terse message and exits with 1.
-- `-h, --help` is listed in each command's options, appended last. To control
+- `--help`/`-h` alone prints help for all commands (or usage help for a command-less CLI) and exits with status 0.
+- `some-command --help`/`some-command -h` prints help for `some-command` and exits with status 0.
+This also works for multi-word commands, e.g., `some-prog deps outdated --help` would show help for the `deps outdated` command.
+- A mistyped or missing command prints a terse message and exits with a status of 1.
+- `-h, --help` is listed in each command's available options, appended last. To control
   the order, give the command entry an `:order` (a vector of option keys); it
   is used verbatim, so you decide the order, which options to list, and whether
-  to list `--help` at all (omit `:help` to hide it; it still works):
+  to list `--help` at all (omit `:help` from `:order` to hide it; but note, it will still work).
+  An example `dispatch` command entry that lists `--help` first:
 
-  ``` clojure
-  {:cmds [...] :spec {...} :order [:help :port :verbose]}   ; --help first
-  ```
+  - tree format
+    ```clojure
+    {:cmd {"foo" {:spec {...} :order [:help :port :verbose]}}}
+    ```
+  - table format
+    ``` clojure
+    {:cmds ["foo"] :spec {...} :order [:help :port :verbose]}
+    ```
 
   Without `:order`, the order is taken from the spec (a vec-of-pairs spec keeps
   its order; a map follows its key order, which Clojure does not guarantee), and
   `--help` is appended.
-- `--help`/`-h` are reserved while `:help` is on (a command may still define its
+- `--help`/`-h` are reserved when `:help true` is specified (a command may still define its
   own `:help`).
-- An entry's `:epilog` (a string) is rendered verbatim after that command's
-  options, for examples, notes or links. Put it on the root entry (`:cmds []`)
-  for the top-level help.
+- A command entry's `:epilog` (a string) is rendered verbatim after that command's
+  options, for examples, notes or links. Specify it at the root of the commands tree format (or `:cmds []` entry for commands table format) for the top-level help.
 
-It works for a single-command CLI too: a one-entry table whose `:cmds` is `[]`.
-`example --help` then shows Usage + Options:
+The `:help true` option works for a command-less CLI too.
+`some-prog --help` then shows Usage + Options:
 
-``` clojure
-(cli/dispatch [{:cmds [] :fn run :spec {:port {:coerce :long :desc "Port"}}}]
-              args
-              {:prog "example" :help true})
-```
+- tree format
+  ```clojure
+  (cli/dispatch {:fn run :spec {:port {:coerce :long :desc "Port"}}}
+                args
+                {:prog "some-prog" :help true})
+  ```
+- table format
+  ``` clojure
+  (cli/dispatch [{:cmds [] :fn run :spec {:port {:coerce :long :desc "Port"}}}]
+                args
+                {:prog "some-prog" :help true})
+  ```
 
-`--help`/`-h` are a success path: they print help and return (no exit call), so
-your `-main` ends and the process exits 0, like a normal command. Errors go
+`--help`/`-h` are success paths: they print help and return naturally (no exit call), so
+your `-main` ends and the process exits with a status of 0, like a normal command. Errors go
 through the dynamic `*exit-fn*`, which exits non-zero:
 
 | invocation | outcome |
 |---|---|
 | `--help` / `-h` | print help, return (status 0), no `*exit-fn*` |
-| group, no subcommand | terse message, `*exit-fn*` exit 1, `:cause :input-exhausted` |
-| unknown subcommand | terse message, `*exit-fn*` exit 1, `:cause :no-match` |
-| flag error | terse message, `*exit-fn*` exit 1, `:cause` = the babashka.cli cause |
+| no command or incomplete multi-word command | terse message, `*exit-fn*` exit 1, `:cause :input-exhausted` |
+| unknown command | terse message, `*exit-fn*` exit 1, `:cause :no-match` |
+| option error | terse message, `*exit-fn*` exit 1, `:cause` = the babashka.cli cause |
 
-A bare group is a usage error (exit 1), like `git bisect` with no subcommand;
-its full help is one keystroke away via `--help`. `*exit-fn*` is called only on
-errors, with `{:exit :cause :dispatch :data}` (`:cause` is the dispatch cause:
-`:no-match`, `:input-exhausted`, or a flag cause; `:data` holds the raw
-`dispatch` error data). The default exits the process (`System/exit` on JVM,
-`js/process.exit` on Node); rebind it to not exit (tests, REPL) or to remap
-codes by `:cause`:
+You can include a `:doc` without a `:fn` to describe a grouping of multi-word commands.
+For example, `git bisect` is not something we can invoke, but we can get `--help` for it:
+```clojure
+(cli/dispatch
+  {:cmd {"bisect"
+         {:doc "general bisect help"
+          :cmd {"start" {:fn identity :doc "start the bisect"}
+                "good"  {:fn identity :doc "commit is good"}
+                "bad"   {:fn identity :doc "commit is bad"}}}}}
+  ["bisect" "--help"]
+  {:prog "git" :help true})
+```
+Outputs:
+```
+Usage: git bisect [options] <command>
 
-``` clojure
-;; treat a bare group as success (exit 0) instead of a usage error
-(binding [cli/*exit-fn* (fn [{:keys [exit cause]}]
-                          (System/exit (if (= :input-exhausted cause) 0 exit)))]
-  (cli/dispatch table args {:prog "example" :help true}))
+general bisect help
+
+Commands:
+  start start the bisect
+  good  commit is good
+  bad   commit is bad
+
+Options:
+  -h, --help  Show this help
+
+Run "git bisect <command> --help" for more information on a command.
 ```
 
-Both handlers are overridable: pass your own `:help-fn` (called with
-`{:tree :dispatch :prog :inherit}`) and/or `:error-fn` to `dispatch`. To render
-the standard help and add to it, call `format-command-help`, the same renderer
+`*exit-fn*` is called on errors, with map `{:exit :some-dispatch-cause :dispatch :some-data}`
+- `:some-dipatch-cause` can be`:no-match`, `:input-exhausted`, or an option cause.
+- `:some-data` holds the raw `dispatch` error data.
+- the default implementation exits the process (`System/exit` on JVM, `js/process.exit` on Node)
+- rebind it to not exit (for tests, REPL use) or to remap codes by `:cause`
+
+  ``` clojure
+  ;; treat an incomplete multi-word command as success (exit 0) instead of a usage error
+  (binding [cli/*exit-fn* (fn [{:keys [exit cause]}]
+                            (System/exit (if (= :input-exhausted cause) 0 exit)))]
+    (cli/dispatch table args {:prog "example" :help true}))
+  ```
+
+You can optionally override help and error handlers via `dispatch` `:help-fn` and `:error-fn` options.
+
+To render the standard help and add to it, call `format-command-help`, the same renderer
 the default uses:
 
 ``` clojure
@@ -775,13 +1045,13 @@ The `dispatch` function can generate dynamic shell completions for `bash`,
 each TAB to generate completions. The `:prog` (program name) value is essential
 in the `dispatch` call. The generated snippet registers completion for that
 name, so it must match the command you type, and it must be a plain command name
-consisting of only alphanumeric characters, `.`, `_` or `-`.
+consisting of only alphanumeric characters, `.`, `_`, or `-`.
 
 ``` clojure
 (cli/dispatch table args {:prog "mycli" :help true})
 ```
 
-If the installed command has a different name, e.g. when a distro renames it, pass
+If the installed command has a different name, e.g., when a distro renames it, pass
 `--prog <name>` when generating the snippet to register that name instead:
 
 ``` bash
@@ -789,17 +1059,17 @@ mycli org.babashka.cli/completions snippet --shell zsh --prog sq
 ```
 
 The completions call goes through a hidden `org.babashka.cli/completions`
-subcommand group that `dispatch` adds for you. Running `mycli
+command group that `dispatch` adds for you. Running `mycli
 org.babashka.cli/completions snippet --shell <shell>` prints the install snippet
 for that specific shell to stdout. It does not write files or edit your shell
 config for you.
 
-Subcommands and options come with completion support out of the box. Descriptions come from the
-same `:desc` (options) and `:doc` (subcommands) you already write for `--help`. A
-`:no-doc` subcommand or option is hidden. Options that already appeared are filtered
-out of later suggestions, except repeatable options (e.g. `:coerce [:string]`).
+Commands and options come with completion support out of the box. Descriptions come from the
+same `:desc` (options) and `:doc` (commands) you already write for `--help`. A
+`:no-doc` command or option is hidden. Options that already appeared are filtered
+out of later suggestions, except repeatable options (e.g., `:coerce [:string]`).
 
-Here follow the instructions to enable auto-completions in your shell.
+Instructions follow to enable auto-completions in your shell.
 
 ### Bash
 
@@ -821,7 +1091,7 @@ Add this to your zsh init file, after `compinit`:
 source <(mycli org.babashka.cli/completions snippet --shell zsh)
 ```
 
-or save the output as `_mycli` on your `$fpath`. Option and subcommand
+or save the output as `_mycli` on your `$fpath`. Option and command
 descriptions show inline. Completions also fire when the program is invoked by
 path, such as `./mycli`.
 
@@ -831,7 +1101,7 @@ path, such as `./mycli`.
 mycli org.babashka.cli/completions snippet --shell fish | source
 ```
 
-Option and subcommand descriptions show inline. Completion also fires on a path
+Option and command descriptions show inline. Completion also fires on a path
 invocation.
 
 ### Powershell
@@ -870,7 +1140,7 @@ than `mycli`, so several tools can install side by side.
 Completions are registered for the command name `:prog`, so the command you type must
 match it. During development you usually invoke the build directly, e.g.
 `./run.clj`, under a different name. Make the dev build callable under your `:prog`
-name on `PATH`. On unix shells, symlink it and prepend its directory:
+name on `PATH`. On Unix shells, symlink it and prepend its directory:
 
 ``` bash
 ln -sf "$PWD/run.clj" /tmp/mycli                   # name the link :prog
@@ -886,9 +1156,9 @@ its section above, and re-source it after each change to your CLI so new command
 options show up.
 
 Now `mycli <TAB>` completes commands and `mycli sub --<TAB>` its options. To see the
-completer's raw output directly, without a shell, call the hidden subcommand
+completer's raw output directly, without a shell, call the hidden command
 yourself. The tokens after `--` are what the shell would pass on TAB, here the
-subcommand `sub` and a `--` to complete its options. It prints one candidate per
+command `sub` and a `--` to complete its options. It prints one candidate per
 line, as the value, a tab, then the description:
 
 ``` bash
@@ -935,11 +1205,11 @@ shell's own file completion the same way. So `:args->opts [:file]` with a bare
 out here too.
 
 ## Adding Production Polish
-Babashka cli lets you get up and running quickly.
+Babashka CLI lets you get up and running quickly.
 As you move toward production quality, it's helpful to let users know when their inputs are invalid.
 Strict validation can be introduced with [:restrict](#restrict), [:require](#require), and [:validate](#validate).
 
-As you add polish, you'll likely make use of a [:spec](#spec), a custom [:error_fn](#error-handling), and maybe [subcommand dispatching](#subcommands).
+As you add polish, you'll likely make use of a [:spec](#spec) and maybe a custom [:error_fn](#error-handling). Even if your program does not use [commands](#commands), consider using `dispatch` with the `:help true` option (as shown in [Simple Example](#simple-example)) for printed terse error messages (instead of exceptions), and automatic `--help` generation.
 
 ## Restrict
 
@@ -949,7 +1219,7 @@ Use the `:restrict` option to restrict options to only those explicitly mentione
 (cli/parse-args ["--foo"] {:spec {:bar {}} :restrict true})
 ;;=>
 Execution error (ExceptionInfo) at babashka.cli/parse-opts (cli.cljc:357).
-Unknown option: :foo
+Unknown option: --foo
 ```
 
 ## Require
@@ -961,7 +1231,7 @@ when it is not present:
 (cli/parse-args ["--foo"] {:spec {:bar {:require true}}})
 ;;=>
 Execution error (ExceptionInfo) at babashka.cli/parse-opts (cli.cljc:363).
-Required option: :bar
+Required option: --bar
 ```
 
 Required options are shown as `(required)` in `--help`, in the slot a default
@@ -972,7 +1242,7 @@ would otherwise occupy.
 ``` clojure
 (cli/parse-args ["--foo" "0"] {:spec {:foo {:validate pos?}}})
 Execution error (ExceptionInfo) at babashka.cli/parse-opts (cli.cljc:378).
-Invalid value for option :foo: 0
+Invalid value for option --foo: 0
 ```
 
 To gain more control over the error message, use `:pred` and `:ex-msg`:
@@ -1018,7 +1288,7 @@ The following keys are present depending on `:cause`:
 - `:cause :coerce`
   - `:value` - the value of the option that failed coercion.
 
-By default, babashka cli will throw exception on errors it detects.
+By default, babashka CLI will throw exceptions on errors it detects.
 You can do the same from your custom error handler.
 
 For a more polished user experience, you might choose to have your custom error handler print the error and exit. For example:
@@ -1047,7 +1317,7 @@ Missing required argument:
   --foo <val> You know what this is.
 ```
 
-You can also choose collect and then report all detected errors (see `babashka.cli-test/error-fn-test` for an example of this).
+You can also choose to collect and then report all detected errors (see `babashka.cli-test/error-fn-test` for an example of this).
 
 ## Adding default args
 
@@ -1083,7 +1353,7 @@ This will print:
   -p, --pretty         Pretty-print output.
 ```
 
-As options can often be re-used in multiple subcommands, you can determine the
+As options can often be reused in multiple commands, you can determine the
 order _and_ selection of printed options with `:order`. If you don't want to use
 `:order` and simply want to present the options as written, you can also use a
 vector of vectors for the spec:
@@ -1098,8 +1368,8 @@ vector of vectors for the spec:
 ```
 
 If you need more flexibility, you can also use `opts->table`, which turns a spec into a vector of vectors, representing rows of a table.
-You can then use`format-table` to produce a table as returned by `format-opts`.
-For example to add a header row with labels for each column, you could do something like:
+You can then use `format-table` to produce a table as returned by `format-opts`.
+For example, to add a header row with labels for each column, you could do something like:
 
 ``` clojure
 (cli/format-table
@@ -1156,14 +1426,16 @@ book](https://book.babashka.org/#cli).
 
 ## Clojure CLI
 
+The Clojure CLI supports [invoking a function with a single map arg](https://clojure.org/reference/clojure_cli#use_fn) via the `-X` command line option.
+Because `-X` does no automatic coercion of values, getting the command-line correct can be, at best, awkward on macOS and Linux, and often an exercise of real frustration on Windows.
+
 You can control parsing behavior by adding `:org.babashka/cli` metadata to
 Clojure functions. It does not introduce a dependency on `babashka.cli`
 itself. Not adding any metadata will result in string values, which in many
 cases may already be a reasonable default.
 
-Adding support for this library will cause less friction with shell usage,
-especially on Windows since you need less quoting. You can support the same
-function for both `clojure -X` and `clojure -M` style invocations without
+Adding support for babashka CLI will cause less friction with shell usage.
+You can support the same function for both `clojure -X` and `clojure -M` style invocations without
 writing extra boilerplate.
 
 In your `deps.edn` `:aliases` entry, add:

--- a/README.md
+++ b/README.md
@@ -994,8 +994,8 @@ Run "git bisect <command> --help" for more information on a command.
 
 `*exit-fn*` is called on errors, with a map with keys:
 - `:exit` exit code
-- `:cause` can be`:no-match`, `:input-exhausted`, or an option cause.
-- `:dispatch` the matched  command
+- `:cause` can be `:no-match`, `:input-exhausted`, or an option cause.
+- `:dispatch` the matched command
 - `:data` raw dispatch error data
 
 The default `*exit-fn*` implementation exits the process (`System/exit` on JVM, `js/process.exit` on Node).

--- a/README.md
+++ b/README.md
@@ -707,8 +707,8 @@ A contrived example to illustrate:
 
 ``` clojure
 (def root-spec {:foo {:coerce #(str "global-" %)}})
-(def level1-spec {:bar {:coerce #(str "sub1-" %)}})
-(def level2-spec {:baz {:coerce #(str "sub2-" %)}})
+(def sub1-spec {:bar {:coerce #(str "sub1-" %)}})
+(def sub2-spec {:baz {:coerce #(str "sub2-" %)}})
 
 (def tree
   {:spec root-spec

--- a/README.md
+++ b/README.md
@@ -858,11 +858,11 @@ The table format represents this structure flatly:
 
 ```clojure
 (def table
-  [{:cmds [] :spec {:verbose {coerce :boolean :inherit true :desc "Verbose output"}}} ;; top-level options
+  [{:cmds [] :spec {:verbose {:coerce :boolean :inherit true :desc "Verbose output"}}} ;; top-level options
    {:cmds ["copy"] :fn copy :doc "Copy a file" :args->opts [:file]
                    :spec {:dry-run {:coerce :boolean :desc "Do a dry run"}}}
-   {:cmds ["cache" :doc "Manage the cache"]}
-   {:cmds ["cache clean"] :fn clean :doc "Clean the cache"}])
+   {:cmds ["cache"] :doc "Manage the cache"}
+   {:cmds ["cache" "clean"] :fn clean :doc "Clean the cache"}])
 
 (cli/dispatch table args {:prog "example" :help true})
 ```

--- a/README.md
+++ b/README.md
@@ -992,14 +992,17 @@ Options:
 Run "git bisect <command> --help" for more information on a command.
 ```
 
-`*exit-fn*` is called on errors, with map `{:exit :some-dispatch-cause :dispatch :some-data}`
-- `:some-dipatch-cause` can be`:no-match`, `:input-exhausted`, or an option cause.
-- `:some-data` holds the raw `dispatch` error data.
-- the default implementation exits the process (`System/exit` on JVM, `js/process.exit` on Node)
-- rebind it to not exit (for tests, REPL use) or to remap codes by `:cause`
+`*exit-fn*` is called on errors, with a map with keys:
+- `:exit` exit code
+- `:cause` can be`:no-match`, `:input-exhausted`, or an option cause.
+- `:dispatch` the matched  command
+- `:data` raw dispatch error data
+
+The default `*exit-fn*` implementation exits the process (`System/exit` on JVM, `js/process.exit` on Node).
+Rebind it to not exit (for tests, REPL use) or to remap codes by `:cause`, for example:
 
   ``` clojure
-  ;; treat an incomplete multi-word command as success (exit 0) instead of a usage error
+  ;; treat a missing command or incomplete multi-word command as success (exit 0) instead of a usage error
   (binding [cli/*exit-fn* (fn [{:keys [exit cause]}]
                             (System/exit (if (= :input-exhausted cause) 0 exit)))]
     (cli/dispatch table args {:prog "example" :help true}))

--- a/README.md
+++ b/README.md
@@ -531,6 +531,9 @@ arguments. Without `:args->opts`, `dispatch` stops at the first positional argum
 
 Babashka CLI handles commands with [dispatch](/API.md#dispatch).
 
+> [!NOTE]
+> When we use the word "command" in this README or other documentation in this library, it's the same concept as what many CLI libraries call "subcommands". We use "command" for consistency since technically a single-word command is not a _sub_-command.
+
 ### Single-word Commands
 
 Say we want a CLI with a `copy` command, a `delete` command, and an undocumented `debug` command:

--- a/README.md
+++ b/README.md
@@ -542,7 +542,7 @@ $ example debug
 ```
 
 Commands can be specified in two ways: as a tree or a table.
-The difference is more apparrent for [Multi-word Commands](#multi-word-commands).
+The difference is more apparent for [Multi-word Commands](#multi-word-commands).
 We'll use the tree structure for this example, save it to `try_cmds.clj`.
 
 ```clojure
@@ -590,7 +590,7 @@ Regardless of tree or table format, each command entry accepts any [parse-args](
 `:args->opts`, `:alias`, `:restrict`, ...).
 
 > [!NOTE]
-> If you want to try `try_cmd.clj`  from your terminal:
+> If you want to try `try_cmds.clj`  from your terminal:
 >
 > - For babashka, create `bb.edn` in the same dir:
 >     ```clojure

--- a/README.md
+++ b/README.md
@@ -553,6 +553,7 @@ We'll use the tree structure for this example, save it to `try_cmds.clj`.
   (prn :copy opts))
 
 (defn delete [{:keys [opts]}]
+  (prn :delete opts))
 
 (def tree
   {:cmd {"copy"   {:fn copy :doc "Copy a file\nMore details here" :args->opts [:file]
@@ -562,7 +563,7 @@ We'll use the tree structure for this example, save it to `try_cmds.clj`.
                           :depth     {:coerce :long    :desc "Max depth"}}}
          "debug"  {:fn prn :doc "Dump internal state"}}
    ;; specify which commands to show and in what order (we exclude hidden debug command)
-   :cmd-order ["copy" "delete"]}])
+   :cmd-order ["copy" "delete"]})
 
 (defn -main [& args]
   (cli/dispatch tree args {:prog "try-cmds" :help true}))

--- a/src/babashka/cli.cljc
+++ b/src/babashka/cli.cljc
@@ -199,7 +199,7 @@
 
 (defn parse-cmds
   "Parses sub-commands (arguments not starting with an option prefix). Returns a map with:
-  * `:cmds` - The parsed subcommands
+  * `:cmds` - The parsed commands
   * `:args` - The remaining (unparsed) arguments"
   ([args] (parse-cmds args nil))
   ([args {:keys [no-keyword-opts]}]
@@ -289,7 +289,7 @@
 
   Supported options:
   * `:coerce` - a map of option (keyword) names to type keywords (optionally wrapped in a collection).
-  * `:spec` - a spec of options. See [spec](https://github.com/babashka/cli#spec).
+  * `:spec` - a spec of options. See [spec](/README.md#spec).
   * `:error-fn` - error handler, called with a map containing `:cause` (`:coerce`), `:msg`, `:option`, `:value`, `:opts`, and `:flag` (when the option was typed).
 
   `:flag` is the literal option token as it appeared on the command line (e.g.
@@ -627,15 +627,15 @@
   Supported `opts`:
   * `:coerce` - a map of option (keyword) names to type keywords (optionally wrapped in a collection.)
   * `:alias` - a map of short names to long names.
-  * `:spec` - a spec of options. See [spec](https://github.com/babashka/cli#spec).
+  * `:spec` - a spec of options. See [spec](/README.md#spec).
   * `:restrict` - `true` or coll of keys. Throw on first parsed option not in set of keys or keys of `:spec` and `:coerce` combined.
-  * `:require` - a coll of options that are required. See [require](https://github.com/babashka/cli#restrict).
-  * `:validate` - a map of validator functions. See [validate](https://github.com/babashka/cli#validate).
+  * `:require` - a coll of options that are required. See [require](/README.md#restrict).
+  * `:validate` - a map of validator functions. See [validate](/README.md#validate).
   * `:exec-args` - a map of default args. Will be overridden by args specified in `args`. Values from `:exec-args` are NOT coerced or auto-coerced; provide them in their final form. Not subject to `:restrict`.
   * `:no-keyword-opts` - `true`. Support only `--foo`-style opts (i.e. `:foo` will not work).
   * `:repeated-opts` - `true`. Forces writing the option name for every value, e.g. `--foo a --foo b`, rather than `--foo a b`
   * `:args->opts` - consume unparsed commands and args as options
-  * `:collect` - a map of collection fns. See [custom collection handling](https://github.com/babashka/cli#custom-collection-handling).
+  * `:collect` - a map of collection fns. See [custom collection handling](/README.md#custom-collection-handling).
 
   Examples:
 
@@ -789,9 +789,12 @@
                        (range max-lines))))
               rows))))
 
-(defn format-table [{:keys [rows indent divider wrap max-width-fn]
-                     :or {indent 2 divider " " wrap true max-width-fn default-width-fn}
-                     :as cfg}]
+(defn format-table
+  "Formats `rows` into a table (string).
+  See [Printing options](/README.md#printing-options)."
+  [{:keys [rows indent divider wrap max-width-fn]
+    :or {indent 2 divider " " wrap true max-width-fn default-width-fn}
+    :as cfg}]
   (let [rows (cond-> rows
                (and wrap (seq rows))
                ;; max-width-fn is called only here (lazy): no detection when not wrapping
@@ -838,7 +841,10 @@
   ;;     "                           r3c3 l3"]
   )
 
-(defn opts->table [{:keys [spec order columns]}]
+(defn opts->table
+  "Converts options to a table of rows.
+  See [Printing options](/README.md#printing-options)."
+  [{:keys [spec order columns]}]
   (let [columns (set (or columns (mapcat (fn [[_ s]] (keys s)) spec)))]
     (mapv (fn [[long-opt {:keys [alias default default-desc ref desc negatable]}]]
             (keep identity
@@ -872,7 +878,7 @@
                   (map (fn [k] [k (spec k)]) (or order (keys spec)))
                   spec)
         ;; `:no-doc` options still parse but are hidden from help, like `:no-doc`
-        ;; subcommands are hidden from the command list
+        ;; commands are hidden from the command list
         entries (remove (fn [[_ v]] (:no-doc v)) entries)
         ;; effective required set, matching validation: per-option `:require true`
         ;; or membership in a top-level `:require` coll (both fold into one set)
@@ -894,9 +900,13 @@
               [inv desc]))
           entries (map short entries))))
 
-(defn format-opts [{:as cfg
-                    :keys [indent wrap max-width-fn]
-                    :or {indent 2 wrap true max-width-fn default-width-fn}}]
+(defn format-opts
+  "Formats options into an options usage help string.
+
+  See [Printing options](/README.md#printing-options)."
+  [{:as cfg
+    :keys [indent wrap max-width-fn]
+    :or {indent 2 wrap true max-width-fn default-width-fn}}]
   (format-table {:rows (opts->help-rows cfg)
                  :indent indent
                  :divider "  "
@@ -931,7 +941,7 @@
           :else (recur (next s) (conj acc (str "<" (name k) ">")) k (inc n)))))))
 
 (defn- cmd-children
-  "Visible `[name child]` pairs of `node`'s subcommands, for display (help,
+  "Visible `[name child]` pairs of `node`'s commands, for display (help,
   completions, error suggestions): `:no-doc` children are dropped. An explicit
   node `:cmd-order` (vector of names) selects which children are shown and in
   what order, like `:order` does for options. Without it: the declaration
@@ -948,7 +958,7 @@
   (str "Usage: " prog
        (when any-options? " [options]")
        ;; `<command>` reflects the runtime contract (the node accepts/requires
-       ;; a subcommand), so it keys on the dispatchable children, not the
+       ;; a command), so it keys on the dispatchable children, not the
        ;; visible ones: a node may hide all children and still demand one
        (cond (seq (:cmd node)) " <command>"
              ;; a runnable command: show labeled positionals from :args->opts, if
@@ -1228,7 +1238,7 @@
                   (map (fn [[a l]] [(format-short-opt a) l]) aliases)))))
 
 (defn- command-candidates
-  "Subcommand candidates of `node` completing `to-complete`."
+  "Command candidates of `node` completing `to-complete`."
   [node to-complete]
   (keep (fn [[cmd subnode]]
           (when (true-prefix? to-complete cmd)
@@ -1253,7 +1263,7 @@
 
 (defn- descend
   "Walk the completed prefix `tokens` down dispatch tree `tree`, consuming
-  subcommands and options with their values, accumulating `:inherit`-ed spec
+  commands and options with their values, accumulating `:inherit`-ed spec
   entries like dispatch-tree' does. Returns
   `[[opts aliases known] deepest-node tokens-at-deepest-level end-of-options?]`."
   [tree global-opts tokens]
@@ -1328,7 +1338,7 @@
                    (positional-candidates node spec pos-args parsed raw-last))))))))
 
 ;; The stub a user installs. On each TAB it calls the program back with the
-;; hidden `org.babashka.cli/completions complete` subcommand, passing the
+;; hidden `org.babashka.cli/completions complete` command, passing the
 ;; shell-tokenized words up to the cursor, and renders the
 ;; `value<TAB>description` lines that come back.
 (defn- completion-shell-snippet [shell program-name]
@@ -1505,7 +1515,7 @@ $env.config.completions.external.completer = {|spans|
   `inherit` value, compute everything [[render-help]] needs: the target `:node`,
   its full `:prog` path, the `:inherited` options usable here (aggregated from
   ancestors) and the `:parents` pointers (ancestors with non-inherited options
-  that must precede the subcommand).
+  that must precede the command).
 
   Specs are mapified here for set reasoning (a standalone `format-command-help`
   spec may be a vec-of-pairs); display order is handled by `render-help`."
@@ -1524,7 +1534,7 @@ $env.config.completions.external.completer = {|spans|
                     {:pre pre :inh inh :own (apply dissoc spec (keys inh))})
         inherited (reduce merge {} (map :inh ancestors))
         ;; ancestors with non-inherited options that aren't also available here
-        ;; (those must be given before the subcommand)
+        ;; (those must be given before the command)
         parents (for [{:keys [pre own]} ancestors
                       :let [own (apply dissoc own here)]
                       :when (seq own)]
@@ -1537,7 +1547,7 @@ $env.config.completions.external.completer = {|spans|
 
 (defn format-command-help
   "Render conventional `--help` text (a string) for the command at path `cmds`
-  in a `dispatch` table or tree:
+  in a `dispatch` table or tree.
 
   ```
   Usage: <prog> [options] <command>
@@ -1580,12 +1590,12 @@ $env.config.completions.external.completer = {|spans|
 
 (defn ^:dynamic *exit-fn*
   "Terminates the process after `dispatch`'s `:help` option prints an *error*
-  (unknown/missing subcommand, flag error). `--help`/`-h` is not an error - it
+  (unknown/missing command, option error). `--help`/`-h` is not an error - it
   prints help and returns, so it does not call this. Called with a map:
 
   * `:exit` - exit code (always non-zero, `1`)
-  * `:cause` - the dispatch error cause: `:no-match` (unknown subcommand),
-    `:input-exhausted` (group with no subcommand), or the flag cause
+  * `:cause` - the dispatch error cause: `:no-match` (unknown command),
+    `:input-exhausted` (no command or incomplete multi-word command), or the option cause
     (`:restrict` / `:require` / `:validate` / `:coerce`)
   * `:dispatch` - the command path
   * `:data` - the original `dispatch` error data
@@ -1617,17 +1627,17 @@ $env.config.completions.external.completer = {|spans|
   (println (format-command-help {:table tree :cmds (or dispatch []) :prog prog :inherit inherit})))
 
 (defn format-command-error
-  "Render a terse, helpful message (a string) for a dispatch error, given the
-  data `dispatch` passes to its `:error-fn`:
+  "Render a terse, helpful message (a string) for a dispatch error.
+  It is given the data `dispatch` passes to its `:error-fn`:
 
-  * `:no-match` (unknown subcommand) -> message + commands + hint
-  * `:input-exhausted` (group, no subcommand) -> message + commands + hint
-  * flag error (`:restrict` / `:require` / `:validate` / `:coerce`) -> message
+  * `:no-match` (unknown command) -> message + commands + hint
+  * `:input-exhausted` (no command or incomplete multi-word command) -> message + commands + hint
+  *  option error (`:restrict` / `:require` / `:validate` / `:coerce`) -> message
     + usage + hint
 
   Reads the command tree, `:prog`, `:inherit`, `:dispatch` (the path), and for
-  flag errors `:msg` (and for `:no-match`, `:wrong-input`) from the data.
-  Messages name the flag as typed (`--foo`/`-x`), not `:foo`.
+  option errors `:msg` (and for `:no-match`, `:wrong-input`) from the data.
+  Messages name the option as typed (`--foo`/`-x`), not `:foo`.
 
   This is the renderer the `:help` option's default `:error-fn` uses (it prints
   this, then calls [[*exit-fn*]]). Call it from a custom `:error-fn` to keep the
@@ -1643,9 +1653,9 @@ $env.config.completions.external.completer = {|spans|
                 (let [{:keys [node prog inherited]} (ctx-at p)]
                   (help-usage-line prog node (or (seq (:spec node))
                                                  (seq inherited)))))
-        ;; subcommand-level error (unknown / missing): terse message + the
+        ;; command-level error (unknown / missing): terse message + the
         ;; available commands + a pointer to --help
-        subcommand-error
+        command-error
         (fn [message]
           (let [cmds (help-commands-table (:node (ctx-at path)))]
             (str/join "\n"
@@ -1655,13 +1665,13 @@ $env.config.completions.external.completer = {|spans|
                               [hint]))))]
     (cond
       (= :no-match cause)
-      (subcommand-error (str "Unknown command: " wrong-input))
+      (command-error (str "Unknown command: " wrong-input))
 
       (= :input-exhausted cause)
-      (subcommand-error "No subcommand given.")
+      (command-error "No command given.")
 
-      ;; genuine flag error (restrict / require / validate / coerce): terse.
-      ;; The lib message already names the flag the user typed.
+      ;; genuine option error (restrict / require / validate / coerce): terse.
+      ;; The lib message already names the option the user typed.
       :else
       (str/join "\n" [(str "Error: " msg) "" (usage path) "" hint]))))
 
@@ -1711,12 +1721,12 @@ $env.config.completions.external.completer = {|spans|
                         (assoc :spec (deep-merge (deep-merge (->spec-map (:spec opts))
                                                              inherited)
                                                  (->spec-map (:spec kwm)))))
-           ;; thread dispatch context into flag-level errors
+           ;; thread dispatch context into opotion-level errors
            ;; (restrict/require/validate/coerce) so an :error-fn can render help:
            ;; the current path, the program name, dispatch-level :inherit, and the
            ;; command tree
            user-error-fn (:error-fn parse-opts)
-           ;; With the `:help` option on, a flag error (require/validate/restrict/
+           ;; With the `:help` option on, a option error (require/validate/restrict/
            ;; coerce) is stashed rather than fired: a `--help`/`-h` further along
            ;; (e.g. `foo bar --help` where `foo` requires an option) parses at its
            ;; own level and routes to help, and `dispatch-tree` discards the stash.
@@ -1775,7 +1785,7 @@ $env.config.completions.external.completer = {|spans|
   ([tree args]
    (dispatch-tree tree args nil))
   ([tree args opts]
-   (let [;; with `:help` on, flag errors are deferred (stashed) during the walk
+   (let [;; with `:help` on, option errors are deferred (stashed) during the walk
          ;; so a `--help`/`-h` deeper in the args can win - see dispatch-tree'
          error-stash (when (::help opts) (atom []))
          opts (cond-> opts error-stash (assoc ::error-stash error-stash))
@@ -1786,12 +1796,12 @@ $env.config.completions.external.completer = {|spans|
                          (throw (ex-info msg data))))]
      (cond
        ;; --help/-h: success - print help via the :help-fn and return (no exit).
-       ;; Help wins over any stashed flag error.
+       ;; Help wins over any stashed option error.
        (= :help error)
        ((::help-fn opts) (thread-dispatch-context
                           (assoc (select-keys res [:dispatch]) :tree tree)
                           opts))
-       ;; a flag error was stashed during the walk and help did not win: fire the
+       ;; an option error was stashed during the walk and help did not win: fire the
        ;; first one (terse message via :error-fn, which exits non-zero)
        (and error-stash (seq @error-stash))
        ((first @error-stash))
@@ -1892,10 +1902,10 @@ $env.config.completions.external.completer = {|spans|
                      (pr-str sub))))))
 
 (defn dispatch
-  "Subcommand dispatcher.
+  "Command dispatcher.
 
   Dispatches on longest matching command entry in `table` by matching
-  subcommands to the `:cmds` vector and invoking the correspondig `:fn`.
+  commands to the `:cmds` vector and invoking the correspondig `:fn`.
 
   Table is in the form:
 
@@ -1916,7 +1926,7 @@ $env.config.completions.external.completer = {|spans|
                      :cmd {\"clean\" {:fn clean-cache}}}}}
   ```
 
-  The subcommands render in help and completions in the order specified. Map literals with
+  The commands render in help and completions in the order specified. Map literals with
   more than 8 entries lose insertion order, so put a `:cmd-order` (vector of
   child command names) on the map to control which children are shown and in
    what order (like `:order` does for options). A table keeps its entry order
@@ -1931,7 +1941,7 @@ $env.config.completions.external.completer = {|spans|
 
   Use an empty `:cmds` vector to always match or to provide global options.
 
-  For a single-command CLI (no subcommands), use a one-entry table whose `:cmds`
+  For a single-command CLI (no commands), use a one-entry table whose `:cmds`
   is `[]`:
 
   ```clojure
@@ -1945,7 +1955,7 @@ $env.config.completions.external.completer = {|spans|
 
   * `--help`/`-h` print help for the command they precede and return (no error,
     so the process ends with status 0). This goes through a `:help-fn`.
-  * an unknown/missing subcommand or a flag error prints a terse message and
+  * an unknown/missing command or a option error prints a terse message and
     exits non-zero (via [[*exit-fn*]]). This goes through the `:error-fn`.
 
   Both default handlers can be overridden: pass your own `:help-fn` (called with
@@ -1955,7 +1965,7 @@ $env.config.completions.external.completer = {|spans|
 
   Each entry in the table may have additional [[parse-args]] options.
 
-  For more information and examples, see [README.md](README.md#subcommands)."
+  For more information and examples, see [README.md](README.md#commands)."
   ([table args]
    (dispatch table args {}))
   ([table args opts]
@@ -1972,7 +1982,7 @@ $env.config.completions.external.completer = {|spans|
                         (assoc opts ::help true
                                ;; default :error-fn = print the message, then exit;
                                ;; :cause is the dispatch cause as-is (:no-match /
-                               ;; :input-exhausted / a flag cause)
+                               ;; :input-exhausted / an option cause)
                                :error-fn (or (:error-fn opts)
                                              (fn [{:keys [cause dispatch] :as data}]
                                                (print-command-error data)

--- a/src/babashka/cli.cljc
+++ b/src/babashka/cli.cljc
@@ -1906,7 +1906,7 @@ $env.config.completions.external.completer = {|spans|
   "Command dispatcher.
 
   Dispatches on longest matching command entry in `table` by matching
-  commands to the `:cmds` vector and invoking the correspondig `:fn`.
+  commands to the `:cmds` vector and invoking the corresponding `:fn`.
 
   Table is in the form:
 

--- a/src/babashka/cli.cljc
+++ b/src/babashka/cli.cljc
@@ -1722,12 +1722,12 @@ $env.config.completions.external.completer = {|spans|
                         (assoc :spec (deep-merge (deep-merge (->spec-map (:spec opts))
                                                              inherited)
                                                  (->spec-map (:spec kwm)))))
-           ;; thread dispatch context into opotion-level errors
+           ;; thread dispatch context into option-level errors
            ;; (restrict/require/validate/coerce) so an :error-fn can render help:
            ;; the current path, the program name, dispatch-level :inherit, and the
            ;; command tree
            user-error-fn (:error-fn parse-opts)
-           ;; With the `:help` option on, a option error (require/validate/restrict/
+           ;; With the `:help` option on, an option error (require/validate/restrict/
            ;; coerce) is stashed rather than fired: a `--help`/`-h` further along
            ;; (e.g. `foo bar --help` where `foo` requires an option) parses at its
            ;; own level and routes to help, and `dispatch-tree` discards the stash.
@@ -1956,7 +1956,7 @@ $env.config.completions.external.completer = {|spans|
 
   * `--help`/`-h` print help for the command they precede and return (no error,
     so the process ends with status 0). This goes through a `:help-fn`.
-  * an unknown/missing command or a option error prints a terse message and
+  * an unknown/missing command or an option error prints a terse message and
     exits non-zero (via [[*exit-fn*]]). This goes through the `:error-fn`.
 
   Both default handlers can be overridden: pass your own `:help-fn` (called with

--- a/test/babashka/cli/completion_test.cljc
+++ b/test/babashka/cli/completion_test.cljc
@@ -95,7 +95,7 @@
   (testing "no completions for full command"
     (is (= #{} (set (complete cmd-table ["foo"])))))
 
-  (testing "complete subcommands and options"
+  (testing "complete commands and options"
     (is (= #{"bar" "-f" "--foo-opt" "--foo-opt2" "-l" "--foo-flag"} (set (complete cmd-table ["foo" ""])))))
 
   (testing "complete suboption"
@@ -130,7 +130,7 @@
   (is (= #{"-f" "--foo-opt" "--foo-opt2"} (set (complete cmd-table ["foo" "--foo-flag" "-"]))))
   (is (= #{"bar"} (set (complete cmd-table ["foo" "--foo-flag" "b"]))))
 
-  (testing "complete subcommand"
+  (testing "complete command"
     (is (= #{"--bar-opt" "--bar-flag"} (set (complete cmd-table ["foo" "--foo-flag" "bar" ""]))))
     (is (= #{"--bar-opt" "--bar-flag"} (set (complete cmd-table ["foo" "--foo-flag" "bar" "-"]))))
     (is (= #{"--bar-opt" "--bar-flag"} (set (complete cmd-table ["foo" "--foo-flag" "bar" "--"]))))
@@ -159,7 +159,7 @@
 (deftest dispatch-completion-test
   (testing "output is shell-agnostic value<TAB>description data"
     (is (= #{"foo"} (complete-out "myprogram f"))))
-  (testing "descriptions: subcommand :doc and option :desc are surfaced"
+  (testing "descriptions: command :doc and option :desc are surfaced"
     (is (= #{"bar\tThe bar command" "bar-baz"} (complete-out "myprogram ba")))
     (is (= #{"--foo-opt\tThe foo option" "--foo-opt2" "--foo-flag\tEnable foo"}
            (complete-out "myprogram foo --foo")))
@@ -190,7 +190,7 @@
       (is (= ["c" "a"]
              (-> (complete-via-cmd tree {:prog "p"} "p ")
                  str/split-lines)))))
-  (testing "a table with more than 8 subcommands completes in entry order"
+  (testing "a table with more than 8 commands completes in entry order"
     (let [table (mapv (fn [i] {:cmds [(str "cmd" i)] :fn identity}) (range 10))]
       (is (= (mapv #(str "cmd" %) (range 10))
              (complete table [""]))))))
@@ -331,7 +331,7 @@
 
 (deftest no-doc-option-test
   ;; a :no-doc option still parses but is hidden from completion and --help, like a
-  ;; :no-doc subcommand is hidden from the command list
+  ;; :no-doc command is hidden from the command list
   (let [t [{:cmds ["deploy"] :fn identity
             :spec {:env {:coerce :string} :secret {:coerce :string :no-doc true :alias :s}}}]]
     (testing "hidden from completion (long form and alias)"
@@ -409,7 +409,7 @@
 (deftest inherit-completion-test
   (let [t [{:cmds [] :fn identity :spec {:verbose {:coerce :boolean :inherit true}}}
            {:cmds ["sub"] :fn identity :spec {:opt {}}}]]
-    (testing "inherited options are offered at subcommand levels"
+    (testing "inherited options are offered at command levels"
       (is (= #{"--opt" "--verbose"} (set (complete t ["sub" "--"])))))
     (testing "a typed inherited flag is recognized as a flag"
       (is (= #{"--opt"} (set (complete t ["sub" "--verbose" "--"]))))))

--- a/test/babashka/cli_test.cljc
+++ b/test/babashka/cli_test.cljc
@@ -433,7 +433,7 @@
                   {:cmds ["foo" "bar"]
                    :fn identity
                    :spec {:version {:coerce :string}}}])
-      (testing "subcommand wins from args->opts"
+      (testing "command wins from args->opts"
         (is (= {:dispatch ["foo" "bar"], :opts {:version "2000"}, :args ["some-arg"]}
                (-> (cli/dispatch
                     table
@@ -536,7 +536,7 @@
                    (cli/dispatch tree ["dev" "--port" "1234"])))
       (is (submap? {:dispatch ["deps" "outdated"] :opts {}}
                    (cli/dispatch tree ["deps" "outdated"]))))
-    (testing "a root :inherit option is accepted after a subcommand"
+    (testing "a root :inherit option is accepted after a command"
       (is (submap? {:dispatch ["dev"] :opts {:verbose true :port 80}}
                    (cli/dispatch tree ["dev" "--verbose" "--port" "80"]))))
     (testing "--help at every level"
@@ -546,13 +546,13 @@
         (is (nil? exit)))
       (is (str/includes? (:out (run ["deps" "--help"])) "Usage: tool deps"))
       (is (str/includes? (:out (run ["deps" "outdated" "--help"])) "Usage: tool deps outdated")))
-    (testing "unknown subcommand exits via the :error-fn"
+    (testing "unknown command exits via the :error-fn"
       (let [{:keys [out exit]} (run ["nope"])]
         (is (str/includes? out "Unknown command: nope"))
         (is (submap? {:exit 1 :cause :no-match} exit))))
     (testing "bare group exits via the :error-fn"
       (let [{:keys [out exit]} (run ["deps"])]
-        (is (str/includes? out "No subcommand given."))
+        (is (str/includes? out "No command given."))
         (is (submap? {:exit 1 :cause :input-exhausted} exit))))
     (testing "flag error exits via the :error-fn"
       (let [{:keys [out exit]} (run ["dev" "--port" "nan"])]
@@ -582,7 +582,7 @@
        (mapv #(first (str/split (str/trim %) #" +")))))
 
 (deftest cmd-order-test
-  (testing "a table with more than 8 subcommands keeps entry order in help"
+  (testing "a table with more than 8 commands keeps entry order in help"
     (let [table (mapv (fn [i] {:cmds [(str "cmd" i)] :fn identity :doc (str "Cmd " i)})
                       (range 10))
           help (cli/format-command-help {:table table :prog "p"})]
@@ -616,7 +616,7 @@
         (is (= ["a"] (listed-command-names
                       (cli/format-command-error {:cause :no-match :wrong-input "x"
                                                  :dispatch [] :prog "p" :tree tree})))))))
-  (testing "hiding all children does not change the usage line: a subcommand is
+  (testing "hiding all children does not change the usage line: a command is
             still expected at runtime"
     (is (= "Usage: p <command>"
            (cli/format-command-help {:table {:cmd-order [] :cmd {"a" {:fn identity}}}
@@ -808,11 +808,11 @@
                     "Commands:\n  dev  Start dev.\n  deps Dep tools\n\n"
                     "Run \"tool --help\" for more information.")
                s))))
-    (testing ":input-exhausted (bare group) renders the group's subcommands"
+    (testing ":input-exhausted (incomplete multi-word command) renders the group's commands"
       (let [s (cli/format-command-error {:cause :input-exhausted
                                          :dispatch ["deps"] :prog "tool"
                                          :tree (cli/table->tree table)})]
-        (is (str/includes? s "No subcommand given."))
+        (is (str/includes? s "No command given."))
         (is (str/includes? s "outdated"))
         (is (str/includes? s "Run \"tool deps --help\" for more information."))))
     (testing "a flag error renders Error + usage + hint"
@@ -853,7 +853,7 @@
         (is (str/includes? out "Usage: tool [options] <command>"))
         (is (str/includes? out "Commands:"))
         (is (nil? exit))))                  ; help is not an error - *exit-fn* not called
-    (testing "--help after a subcommand renders that command's help"
+    (testing "--help after a command renders that command's help"
       (let [{:keys [out exit]} (run ["deps" "outdated" "--help"])]
         (is (str/includes? out "Usage: tool deps outdated"))
         (is (nil? exit))))
@@ -865,7 +865,7 @@
       (let [{:keys [ran exit]} (run ["dev" "--sync"])]
         (is (nil? exit))
         (is (= {:sync true} (:opts ran)))))
-    (testing "bad subcommand renders help via the installed error-fn, exit 1"
+    (testing "bad command renders help via the installed error-fn, exit 1"
       (let [{:keys [out exit]} (run ["nope"])]
         (is (str/includes? out "Unknown command: nope"))
         (is (submap? {:exit 1 :cause :no-match} exit))))
@@ -907,7 +907,7 @@
         (is (not (str/includes? out "--help")))
         ;; ...but --help still triggers help (prints, returns; no *exit-fn*)
         (is (nil? exit))))
-    (testing "a subcommand that redefines an inherited option shows it under Options, not Inherited"
+    (testing "a command that redefines an inherited option shows it under Options, not Inherited"
       (let [t [{:cmds [] :spec {:x {:inherit true :desc "global x"}}}
                {:cmds ["sub"] :fn identity :spec {:x {:desc "local x"}}}]
             out (:out (run-dispatch t ["sub" "--help"] {:prog "p" :help true}))]
@@ -1133,7 +1133,7 @@
 
 (deftest dispatch-flag-error-includes-dispatch-path-test
   (testing "flag-level errors during dispatch carry the :dispatch path so an
-            :error-fn can render help for the right subcommand"
+            :error-fn can render help for the right command"
     ;; capture the first error and halt (mirrors a real error-fn that exits)
     (let [capture (fn [table args opts]
                     (let [err (atom nil)]
@@ -1151,7 +1151,7 @@
         (let [e (capture table ["--bogus"] {:restrict true})]
           (is (= :restrict (:cause e)))
           (is (= [] (:dispatch e)))))
-      (testing ":restrict at nested subcommand -> full :dispatch path"
+      (testing ":restrict at nested command -> full :dispatch path"
         (let [e (capture table ["foo" "bar" "--bogus"] {:restrict true})]
           (is (= :restrict (:cause e)))
           (is (= ["foo" "bar"] (:dispatch e)))))
@@ -1192,10 +1192,10 @@
   (testing ":inherit options propagate to descendant levels"
     (let [table [{:cmds ["deps"]            :spec {:registry {:alias :r :inherit true}}}
                  {:cmds ["deps" "outdated"] :fn identity :spec {:format {}}}]]
-      (testing "accepted after the subcommand"
+      (testing "accepted after the command"
         (is (= {:dispatch ["deps" "outdated"] :opts {:registry "X" :format "edn"} :args nil}
                (cli/dispatch table ["deps" "outdated" "--registry" "X" "--format" "edn"] {:restrict true}))))
-      (testing "still accepted before the subcommand"
+      (testing "still accepted before the command"
         (is (= {:dispatch ["deps" "outdated"] :opts {:registry "X"} :args nil}
                (cli/dispatch table ["deps" "--registry" "X" "outdated"] {:restrict true}))))
       (testing "alias propagates too"
@@ -1216,7 +1216,7 @@
       (is (= {:tag false}
              (:opts (cli/dispatch table ["ver" "set" "--tag" "false"]
                                   {:spec {:tag {:coerce :string}}}))))))
-  (testing "options without :inherit do NOT propagate (rejected after subcommand)"
+  (testing "options without :inherit do NOT propagate (rejected after command)"
     (let [table [{:cmds ["deps"]            :spec {:registry {}}}
                  {:cmds ["deps" "outdated"] :fn identity :spec {:format {}}}]]
       (is (thrown-with-msg?


### PR DESCRIPTION
To avoid differing nomenclature for bb CLI library users and users of CLIs created with bb CLI, we now describe "subcommands" as "commands".

**One intended behaviour change**: `:input-exhausted` is now reported as "No command given" instead of "No subcommand given".

**The rest are variable renames and doc changes.**

Reviewed docs. Clarified some things, tweaked others.

Turfed use of perhaps confusing jargon like "bare commands".

Reviewed/updated docstrings for quickdoc (some were absent, some summary lines were too long).

Expanded and expounded on "multi-word" commands.

Closes #161
Closes #163