### PR TITLE
error when `--no-foo`ing non :boolean :foo option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ For breaking changes, check [here](#breaking-changes).
 
 [Babashka CLI](https://github.com/babashka/cli): turn Clojure functions into CLIs!
 
+## Unreleased
+
+- [#166](https://github.com/babashka/cli/issues/166): trigger negation invalid error for `--no-foo` when `:foo`'s specified `:coerce` is not `:boolean`
+([@lread](https://github.com/lread))
+
 ## v0.11.74 (2026-06-23)
 
 - [#180](https://github.com/babashka/cli/issues/180): ClojureDart support

--- a/src/babashka/cli.cljc
+++ b/src/babashka/cli.cljc
@@ -118,10 +118,10 @@
 
 (defn- coerce-failure-reason
   "The reason part of a coerce failure, e.g. `cannot transform input \"x\" to long`."
-  [s implicit-true? f]
+  [s implicit-value f]
   (str "cannot transform "
-       (if implicit-true?
-         "(implicit) true"
+       (if implicit-value
+         (str "(implicit) " implicit-value)
          (str "input " (pr-str s)))
        (if (keyword? f)
          " to "
@@ -130,15 +130,20 @@
          (name f)
          f)))
 
-(defn- throw-coerce [s implicit-true? f e]
-  (throw (ex-info (str "Coerce failure: " (coerce-failure-reason s implicit-true? f))
+(defn- throw-coerce [s implicit-value f e]
+  (throw (ex-info (str "Coerce failure: " (coerce-failure-reason s implicit-value f))
                   (cond-> {:input s
                            :coerce-fn f}
-                    implicit-true? (assoc :implicit-true true))
+                    (some? implicit-value) (assoc :implicit-value implicit-value))
                   e)))
 
 (defn- coerce*
-  [s f implicit-true?]
+  "Coerce string `s` using coercer `f`.
+  `implicit-value` can be:
+  - `nil` not an implicit value
+  - `true` for implicit true, e.g., --foo
+  - `false` for implict false, e.g., --no-foo"
+  [s f implicit-value]
   (let [f* (case f
              (:boolean :bool) parse-boolean
              (:int :long) parse-long
@@ -154,10 +159,10 @@
         res (if (string? s)
               (try (f* s)
                    (catch #?(:clj Exception :cljd Object :cljs :default) e
-                     (throw-coerce s implicit-true? f e)))
+                     (throw-coerce s implicit-value f e)))
               s)]
-    (if (and implicit-true? (not (true? res)))
-      (throw-coerce s implicit-true? f nil)
+    (if (and (some? implicit-value) (not= implicit-value res))
+      (throw-coerce s implicit-value f nil)
       res)))
 
 (defn coerce
@@ -320,15 +325,15 @@
          opts (resolve-opts opts)
          coerce-map (:coerce opts)
          m-meta (meta m)
-         implicit-true-keys (or (::implicit-true-keys opts)
-                                (::implicit-true-keys m-meta))
+         implicit-values (or (::implicit-values opts)
+                             (::implicit-values m-meta))
          auto-coerce? (::auto-coerce opts)
          keys-order (or (::keys-order opts)
                         (::keys-order m-meta))
          error-fn (->error-fn spec (:error-fn opts))]
      (if (or (seq coerce-map) auto-coerce?)
-       (let [coerce-1 (fn [v cf implicit-true?]
-                         (if cf (coerce* v cf implicit-true?) (auto-coerce v)))
+       (let [coerce-1 (fn [v cf implicit-value]
+                         (if cf (coerce* v cf implicit-value) (auto-coerce v)))
              ordered-keys (if (seq keys-order)
                             (concat keys-order
                                     (remove (set keys-order) (keys m)))
@@ -341,34 +346,36 @@
                 (let [coll-coerce? (coll? coerce-k)
                       empty-coll (when coll-coerce? (or (empty coerce-k) []))
                       cf (coerce-coerce-fn coerce-k)
-                      it? (and implicit-true-keys (contains? implicit-true-keys k))]
+                      iv (and implicit-values (k implicit-values))]
                   (try
                     (cond
                       (and coll-coerce? (coll? v))
-                      (assoc acc k (reduce (fn [coll elem] (conj coll (coerce-1 elem cf it?))) empty-coll v))
+                      (assoc acc k (reduce (fn [coll elem] (conj coll (coerce-1 elem cf iv))) empty-coll v))
                       coll-coerce?
-                      (assoc acc k (conj empty-coll (coerce-1 v cf it?)))
+                      (assoc acc k (conj empty-coll (coerce-1 v cf iv)))
                       (coll? v)
-                      (assoc acc k (into (empty v) (map #(coerce-1 % cf it?)) v))
+                      (assoc acc k (into (empty v) (map #(coerce-1 % cf iv)) v))
                       :else
-                      (assoc acc k (coerce-1 v cf it?)))
+                      (assoc acc k (coerce-1 v cf iv)))
                     (catch #?(:cljd cljd.core/ExceptionInfo :clj ExceptionInfo :cljs :default) e
                       (let [data (ex-data e)
                             km (::opt->flag m-meta)
-                            flag (get km k)]
+                            flag (get km k)
+                            iv (:implicit-value data)]
                         (error-fn (cond-> {:cause :coerce
                                            ;; same shape as validate: name the option, then the reason.
-                                           ;; implicit-true = option given without a value: say so plainly
+                                           ;; when implicit-value, give a more nuanced error message
                                            ;; instead of "cannot transform (implicit) true to ..."
-                                           :msg (if (:implicit-true data)
-                                                  (str "Missing value for option " (option-label km k))
+                                           :msg (case iv
+                                                  true (str "Missing value for option " (option-label km k))
+                                                  false (str "Negation is invalid " (option-label km k))
                                                   (str "Invalid value for option " (option-label km k) ": "
-                                                       (coerce-failure-reason (:input data) (:implicit-true data) (:coerce-fn data))))
+                                                       (coerce-failure-reason (:input data) iv (:coerce-fn data))))
                                            :option k
                                            :value v
                                            :opts acc}
                                     flag (assoc :flag flag)
-                                    (:implicit-true data) (assoc :implicit-true true))))
+                                    iv (assoc :implicit-value (:implicit-value data)))))
                       acc)))
                 (if auto-coerce?
                   (assoc acc k (auto-coerce v))
@@ -495,7 +502,7 @@
   "Parses CLI `args` into a raw opts map. Returns string values unchanged
   (no coercion), does not apply `:exec-args` defaults, does not run
   `:restrict`/`:require`/`:validate`. Result map includes
-  `:org.babashka/cli` metadata and internal `::implicit-true-keys` /
+  `:org.babashka/cli` metadata and internal `::implicit-values` /
   `::keys-order` metadata used by `coerce-opts`.
 
   Use this when you want to merge other sources (e.g. config files)
@@ -517,8 +524,11 @@
         alias-keys (set (concat (keys aliases) (keep :alias (vals spec-map))))
         known-keys (set (concat (keys spec-map) (vals aliases) (keys coerce)))
         expects-bool-val? (fn [opt-key] (#{:boolean :bool} (coerce-coerce-fn (get coerce opt-key))))
-        track-itk (fn [itk current-opt added]
-                    (cond-> itk (not= current-opt added) (conj current-opt)))
+        track-ivs (fn [implicit-values current-opt added]
+                    ;; we handle implicit trues here only, :add-opt-and-val below covers implicit false
+                    (if (not= current-opt added)
+                      (assoc implicit-values current-opt true)
+                      implicit-values))
         track-kpo (fn [kpo opt]
                     (if (and opt (not (some #{opt} kpo)))
                       (conj kpo opt)
@@ -539,7 +549,7 @@
         [leading-pos-args args] (if (not= new-leading-pos-args args)
                                   [nil (concat new-leading-pos-args args)]
                                   [leading-pos-args args])
-        [parsed last-open-opt last-valued-opt implicit-true-keys key-parse-order]
+        [parsed last-open-opt last-valued-opt implicit-values key-parse-order]
         (if (and (::dispatch-tree parse-opts) (seq leading-pos-args))
           [(vary-meta {} assoc-in [:org.babashka/cli :args] (into (vec leading-pos-args) args)) nil nil #{} []]
           (loop [acc {}
@@ -550,12 +560,12 @@
                  mode (when no-keyword-opts :hyphens) ;; :hyphens --foo/-f else :keywords :foo
                  args (seq args)                      ;; remaining cli args
                  a->o a->o                            ;; requested args->opts
-                 implicit-true-keys #{}
+                 implicit-values {}
                  opt-parse-order []]
             #_(println (format "loop %-31s o: %-10s v: %-10s a: %s" recur-action open-opt valued-opt args))
             (if-not args
               ;; exit loop: no command line args left
-              [acc open-opt valued-opt implicit-true-keys opt-parse-order]
+              [acc open-opt valued-opt implicit-values opt-parse-order]
               (let [raw-arg (first args)
                     opt-injected? (keyword? raw-arg)]
                 (if opt-injected?
@@ -565,10 +575,9 @@
                          :found-injected-opt
                          raw-arg valued-opt
                          mode (next args) a->o
-                         (track-itk implicit-true-keys open-opt valued-opt)
+                         (track-ivs implicit-values open-opt valued-opt)
                          (track-kpo opt-parse-order raw-arg))
-                  (let [implicit-true? (true? raw-arg) ;; injected implicit true
-                        arg (str raw-arg)
+                  (let [arg (str raw-arg)
                         opt-val-collector (collect-fn collect coerce open-opt)
                         boolean-opt? (expects-bool-val? open-opt)
                         {:keys [hyphen-opt composite-opt kwd-opt mode fst-colon]}
@@ -582,7 +591,7 @@
                           (let [nargs (next args)]
                             [(cond-> acc
                                nargs (vary-meta assoc-in [:org.babashka/cli :args] (vec nargs)))
-                             open-opt valued-opt implicit-true-keys opt-parse-order])
+                             open-opt valued-opt implicit-values opt-parse-order])
                           (let [opt-name (if long-opt?
                                            (subs arg 2)
                                            (str/replace arg #"^(:|-|)" ""))
@@ -601,7 +610,7 @@
                                      :injected-bound-val
                                      parsed-opt nil
                                      mode (cons opt-val (rest args)) a->o
-                                     (track-itk implicit-true-keys open-opt valued-opt)
+                                     (track-ivs implicit-values open-opt valued-opt)
                                      (track-kpo opt-parse-order parsed-opt))
                               (let [next-args (next args)
                                     next-arg (first next-args)
@@ -619,7 +628,7 @@
                                              :injected-expanded-composite
                                              nil nil ;; start afresh for open-opt and valued-opt
                                              mode (concat expanded next-args) a->o
-                                             implicit-true-keys opt-parse-order))
+                                             implicit-values opt-parse-order))
                                     (let [parsed-opt (if negated-opt?
                                                        (keyword (str/replace (str parsed-opt) ":no-" ""))
                                                        parsed-opt)]
@@ -628,14 +637,14 @@
                                              :injected-implicit-bool
                                              parsed-opt valued-opt
                                              mode (cons (not negated-opt?) next-args) a->o
-                                             (track-itk implicit-true-keys open-opt valued-opt)
+                                             (track-ivs implicit-values open-opt valued-opt)
                                              (track-kpo opt-parse-order parsed-opt))))
                                   ;; continue loop: not implicit, carry on to parse opt value
                                   (recur (stamp (maybe-close-open-opt acc open-opt valued-opt opt-val-collector) parsed-opt literal-opt)
                                          :found-opt-with-unparsed-val
                                          parsed-opt nil
                                          mode next-args a->o
-                                         (track-itk implicit-true-keys open-opt valued-opt)
+                                         (track-ivs implicit-values open-opt valued-opt)
                                          (track-kpo opt-parse-order parsed-opt))))))))
                       ;; arg (is not option)
                       (let [done-parsing-options? (or
@@ -661,9 +670,9 @@
                                      :injected-trailing-args-to-opts
                                      open-opt valued-opt
                                      mode new-trailing-pos-args a->o
-                                     implicit-true-keys opt-parse-order)
+                                     implicit-values opt-parse-order)
                               ;; exit loop: args -> options resulted in no new args
-                              [(vary-meta acc assoc-in [:org.babashka/cli :args] (vec args)) open-opt valued-opt implicit-true-keys opt-parse-order]))
+                              [(vary-meta acc assoc-in [:org.babashka/cli :args] (vec args)) open-opt valued-opt implicit-values opt-parse-order]))
                           (let [opt (when-not (and (= :keywords mode) fst-colon) open-opt)]
                             ;; continue loop: add/update opt with value (arg), and setup to parse next arg
                             ;; notice the difference from all othe recurs,
@@ -672,17 +681,17 @@
                                    :added-opt-and-val
                                    opt opt ;; keep opt open
                                    mode (next args) a->o
-                                   (cond-> implicit-true-keys implicit-true? (conj open-opt))
+                                   (cond-> implicit-values (boolean? raw-arg) (assoc open-opt raw-arg))
                                    opt-parse-order)))))))))))
         ;; Finalize: process last opt, prepend leading positional args to args metadata
-        implicit-true-keys (track-itk implicit-true-keys last-open-opt last-valued-opt)
+        implicit-values (track-ivs implicit-values last-open-opt last-valued-opt)
         opt-val-collector (collect-fn collect coerce last-open-opt)
         parsed (-> (maybe-close-open-opt parsed last-open-opt last-valued-opt opt-val-collector)
                    (cond->
                     (and (seq leading-pos-args) (not (::dispatch-tree parse-opts)))
                      (vary-meta update-in [:org.babashka/cli :args]
                                 (fn [args] (into (vec leading-pos-args) args)))))]
-    (vary-meta parsed assoc ::implicit-true-keys implicit-true-keys ::keys-order key-parse-order)))
+    (vary-meta parsed assoc ::implicit-values implicit-values ::keys-order key-parse-order)))
 
 (defn parse-opts
   "Returns a map of options parsed from command line arguments `args`, a seq of strings.
@@ -730,7 +739,7 @@
          coerced (apply-defaults coerced opts)
          ;; Step 4: Validate
          validated (validate-opts coerced opts)]
-     (vary-meta validated dissoc ::implicit-true-keys ::keys-order ::opt->flag))))
+     (vary-meta validated dissoc ::implicit-values ::keys-order ::opt->flag))))
 
 (defn parse-args
   "Same as [[parse-opts]] with return data reshaped.

--- a/test/babashka/cli_test.cljc
+++ b/test/babashka/cli_test.cljc
@@ -106,7 +106,29 @@
     (is (= {:option false, :no-this-exists true}
            (cli/parse-opts ["--no-option" "--no-this-exists"] {:coerce {:no-this-exists :bool}})))
     (is (= {:args ["dude"], :opts {:option false}}
-           (cli/parse-args ["--no-option" "dude"] {:coerce {:option :bool}})))))
+           (cli/parse-args ["--no-option" "dude"] {:coerce {:option :bool}})))
+    (is (= {:opts {:option false}}
+           (cli/parse-args ["--no-option"])))
+    (is (= {:opts {:option false}}
+           (cli/parse-args [":no-option"]))))
+  (testing "--no-foo throws on non-boolean"
+    (doseq [coerce-fn [:long :number :symbol :keyword :string]]
+      (is (thrown-with-msg?
+            #?(:cljd Object :default Exception) #"Negation is invalid --no-foo"
+            (cli/parse-opts ["--no-foo"] {:coerce {:foo coerce-fn}}))
+          (str "for coerce to: " coerce-fn))
+      (is (thrown-with-msg?
+            #?(:cljd Object :default Exception) #"Negation is invalid --no-foo"
+            (cli/parse-opts ["--no-foo"] {:coerce {:foo [coerce-fn]}}))
+          (str "for coerce to: [" coerce-fn "]"))
+      (is (thrown-with-msg?
+            #?(:cljd Object :default Exception) #"Negation is invalid :no-foo"
+            (cli/parse-opts [":no-foo"] {:coerce {:foo coerce-fn}}))
+          (str "for coerce to: " coerce-fn))
+      (is (thrown-with-msg?
+            #?(:cljd Object :default Exception) #"Negation is invalid :no-foo"
+            (cli/parse-opts [":no-foo"] {:coerce {:foo [coerce-fn]}}))
+          (str "for coerce to: [" coerce-fn "]")))))
 
 (deftest equals-value-test
   (testing "--opt=val splits on the first = only"
@@ -1320,21 +1342,21 @@
       (cli/coerce-opts {:foo "not-a-number"} {:coerce {:foo :long}
                                               :error-fn (fn [e] (swap! errors conj e))})
       (is (= :coerce (:cause (first @errors))))))
-  (testing "error data includes :implicit-true for implicit-true coerce failures"
+  (testing "error data includes :implicit-value for implicit true coerce failures"
     ;; `--foo` with no value parses to (implicit) `true`. If `:foo` has a
     ;; coerce that rejects boolean true (e.g. `:string`), error data
-    ;; should expose `:implicit-true true` so downstream error mappers
+    ;; should expose `:implicit-value true` so downstream error mappers
     ;; can distinguish "user typed --foo alone" from a real coerce failure.
     (let [errors (atom [])]
       (cli/parse-opts ["--foo"] {:coerce {:foo :string}
                                  :error-fn (fn [e] (swap! errors conj e))})
-      (is (= true (:implicit-true (first @errors))))
+      (is (= true (:implicit-value (first @errors))))
       (is (= :coerce (:cause (first @errors))))))
-  (testing "error data does NOT include :implicit-true for explicit value failures"
+  (testing "error data does NOT include :implicit-value for explicit value coerce failures"
     (let [errors (atom [])]
       (cli/parse-opts ["--foo" "abc"] {:coerce {:foo :long}
                                        :error-fn (fn [e] (swap! errors conj e))})
-      (is (nil? (:implicit-true (first @errors))))
+      (is (nil? (:implicit-value (first @errors))))
       (is (= :coerce (:cause (first @errors))))))
   (testing "keys without coerce spec pass through unchanged"
     (is (= {:foo "1" :bar "hello"}
@@ -1394,8 +1416,8 @@
                (cli/validate-opts {:validate {:foo pos?}}))))))
 
 (deftest internal-meta-not-leaked-test
-  (testing "::implicit-true-keys not in parse-opts result meta"
-    (is (nil? (:babashka.cli/implicit-true-keys (meta (cli/parse-opts ["--foo"]))))))
+  (testing "::implicit-values not in parse-opts result meta"
+    (is (nil? (:babashka.cli/implicit-values (meta (cli/parse-opts ["--foo"]))))))
   (testing "::keys-order not in parse-opts result meta"
     (is (nil? (:babashka.cli/keys-order (meta (cli/parse-opts ["--foo" "--bar" "1"]))))))
   (testing "::opt->flag not in parse-opts result meta"
@@ -1414,11 +1436,11 @@
 (deftest parse-opts-star-test
   (testing "parse-opts* returns raw strings (no coercion)"
     (is (= {:foo "1"} (cli/parse-opts* ["--foo" "1"] {}))))
-  (testing "parse-opts* exposes ::implicit-true-keys + ::keys-order + ::opt->flag in meta"
-    (let [r (cli/parse-opts* ["--foo" "--bar" "1"] {})]
-      (is (= #{:foo} (:babashka.cli/implicit-true-keys (meta r))))
-      (is (= [:foo :bar] (:babashka.cli/keys-order (meta r))))
-      (is (= {:foo "--foo" :bar "--bar"} (:babashka.cli/opt->flag (meta r))))))
+  (testing "parse-opts* exposes ::implicit-values + ::keys-order + ::opt->flag in meta"
+    (let [r (cli/parse-opts* ["--foo" "--bar" "1" "--no-baz"] {})]
+      (is (= {:foo true :baz false} (:babashka.cli/implicit-values (meta r))))
+      (is (= [:foo :bar :baz] (:babashka.cli/keys-order (meta r))))
+      (is (= {:foo "--foo" :bar "--bar" :baz "--no-baz"} (:babashka.cli/opt->flag (meta r))))))
   (testing "parse-opts* skips :restrict / :require / :validate"
     (is (= {:bar "1"} (cli/parse-opts* ["--bar" "1"]
                                        {:restrict #{:foo} :require [:foo]})))))
@@ -1453,7 +1475,7 @@
       (is (= {:paths ["lib"] :output-dir "/tmp/custom" :verbose true} validated)))))
 
 (deftest bool-coerce-parse-key-pinning-test
-  (testing "coll-wrapped :boolean: implicit-true wrapped in coll"
+  (testing "coll-wrapped :boolean: implicit true wrapped in coll"
     (is (= {:foo [true]} (cli/parse-opts ["--foo"] {:coerce {:foo [:boolean]}}))))
   (testing "coll-wrapped :boolean: explicit value coerced and wrapped"
     (is (= {:foo [true]} (cli/parse-opts ["--foo" "true"] {:coerce {:foo [:boolean]}}))))


### PR DESCRIPTION
To support this change, instead of only tracking implicit trues, we now track implicit trues and falses in `parse-opts*`.

Internal key name changes:
- `parse-opts*` metadata `:babashka.cli/implicit-trues` -> `:babashka.cli/implicit-values`
- coerce error data `:implicit-true?` -> `:implicit-value`

Closes #166