### PR TITLE
parse-opts*: resolve spec so :coerce/:collect steer parsing

### DIFF
--- a/src/babashka/cli.cljc
+++ b/src/babashka/cli.cljc
@@ -574,17 +574,19 @@
   -> `coerce-opts` -> `validate-opts`.
 
   Supported options (subset of `parse-opts`): `:alias`/`:aliases`, `:coerce`,
-  `:collect`, `:no-keyword-opts`, `:repeated-opts`, `:args->opts`, `:spec`."
-  [args {:keys [coerce collect no-keyword-opts repeated-opts] :as opts}]
+  `:collect`, `:no-keyword-opts`, `:repeated-opts`, `:args->opts`, `:spec`.
+  A `:spec`'s `:coerce`/`:collect`/`:alias` entries steer parsing (e.g. boolean
+  disambiguation) like they do in `parse-opts` - values still come back raw."
+  [args opts]
   ;; terminology: given cli args ["--foo" "x" "bar"]
   ;;  --foo becomes an "opt"
   ;;  x becomes an option "value"
   ;;  bar remains an "arg"
   ;; parsed "arg"s can only be leading or trailing.
-  (let [parse-opts opts ;; disambiguate from cli opts (without making fn sig odd-looking)
+  (let [parse-opts (resolve-opts opts) ;; disambiguate from cli opts (without making fn sig odd-looking)
+        {:keys [coerce collect no-keyword-opts repeated-opts]} parse-opts
         aliases (or (:alias parse-opts) (:aliases parse-opts))
-        spec (:spec parse-opts)
-        spec-map (or (::spec-map parse-opts) (->spec-map spec))
+        spec-map (::spec-map parse-opts)
         alias-keys (set (concat (keys aliases) (keep :alias (vals spec-map))))
         known-keys (set (concat (keys spec-map) (vals aliases) (keys coerce)))
         expects-bool-val? (fn [opt-key] (#{:boolean :bool} (coerce-coerce-fn (get coerce opt-key))))

--- a/test/babashka/cli_test.cljc
+++ b/test/babashka/cli_test.cljc
@@ -1739,7 +1739,13 @@
       (is (= {:foo "--foo" :bar "--bar" :baz "--no-baz"} (:babashka.cli/opt->flag (meta r))))))
   (testing "parse-opts* skips :restrict / :require / :validate"
     (is (= {:bar "1"} (cli/parse-opts* ["--bar" "1"]
-                                       {:restrict #{:foo} :require [:foo]})))))
+                                       {:restrict #{:foo} :require [:foo]}))))
+  (testing "spec :coerce steers parsing like in parse-opts, values still raw"
+    (let [r (cli/parse-opts* ["--foo" "bar"] {:spec {:foo {:coerce :boolean}}})]
+      (is (= {:foo true} r))
+      (is (= ["bar"] (-> r meta :org.babashka/cli :args))))
+    (is (= {:paths ["a" "b"]} (cli/parse-opts* ["--paths" "a" "b"] {:spec {:paths {:coerce []}}})))
+    (is (= {:n "5"} (cli/parse-opts* ["--n" "5"] {:spec {:n {:coerce :long}}})))))
 
 (deftest apply-defaults-test
   (testing "spec :default fills missing keys"


### PR DESCRIPTION
A direct parse-opts* call honored spec aliases but not spec :coerce/:collect parsing hints, so boolean disambiguation differed from parse-opts. Values still come back raw.